### PR TITLE
Split credentials into a separate endpoint

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -1,6 +1,6 @@
 # auth.md
 
-You are an agent. This service supports **agentic registration**: discover → register → (claim if needed) → call API → handle revocation. Follow the steps in order; do not skip ahead.
+You are an agent. This service supports **agentic registration**: discover → register → (claim if needed) → exchange for an access_token → call API → handle revocation. Follow the steps in order; do not skip ahead.
 
 Examples use placeholder hosts: `https://api.service.example.com` (the resource server hosting the API you want to call) and `https://auth.service.example.com` (the authorization server that handles registration). Real services substitute their own.
 
@@ -41,8 +41,8 @@ What each field tells you:
 - `resource` — the canonical URL of the API you're trying to call. Use this as the `aud` when minting an ID-JAG.
 - `resource_name` / `resource_logo_uri` — display name and logo for the service. Surface these to the user when asking for consent.
 - `authorization_servers` — base URLs of the OAuth Authorization Server(s) for this resource. The `agent_auth` block lives on one of these (see 1b).
-- `scopes_supported` — scopes the resource server understands. The credential you receive will be scoped to some subset; you don't request specific scopes during registration.
-- `bearer_methods_supported` — how you'll send the credential in Step 5 (`"header"` = `Authorization: Bearer …`).
+- `scopes_supported` — scopes the resource server understands. The access_token you receive at Step 5 will be scoped to some subset.
+- `bearer_methods_supported` — how you'll send the access_token in Step 6 (`"header"` = `Authorization: Bearer …`).
 
 ### 1b. Fetch the Authorization Server metadata
 
@@ -58,21 +58,23 @@ Response shape:
   "authorization_servers": ["https://auth.service.example.com/"],
   "scopes_supported": ["api.read", "api.write"],
   "bearer_methods_supported": ["header"],
+
+  "issuer": "https://auth.service.example.com",
+  "token_endpoint": "https://auth.service.example.com/oauth2/token",
+  "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
-    "register_uri": "https://auth.service.example.com/agent/auth",
-    "claim_uri": "https://auth.service.example.com/agent/auth/claim",
+    "identity_endpoint": "https://auth.service.example.com/agent/identity",
+    "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
     "identity_types_supported": ["anonymous", "identity_assertion"],
-    "anonymous": {
-      "credential_types_supported": ["api_key"]
-    },
     "identity_assertion": {
       "assertion_types_supported": [
         "urn:ietf:params:oauth:token-type:id-jag",
         "verified_email"
-      ],
-      "credential_types_supported": ["access_token", "api_key"]
+      ]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -81,17 +83,19 @@ Response shape:
 }
 ```
 
-The outer fields restate the PRM. The `agent_auth` block is the part written for you — read it in full. Every field there is relevant:
+The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `token_endpoint`, `revocation_endpoint`, `grant_types_supported`) are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block is the profile-specific bootstrap surface — read it in full. Every field is relevant:
 
-- `skill` — the URL of this document.
-- `register_uri` — where you POST to register (Step 3).
-- `claim_uri` — where you POST the claim invite (Step 4, anonymous flow only).
-- `revocation_uri` — where the provider POSTs a `logout+jwt` to revoke your credential. You don't call this; it tells you what to expect.
-- `identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
-- `anonymous.credential_types_supported` — credential shapes available when registering anonymously.
-- `identity_assertion.assertion_types_supported` — which assertion types this service accepts (ID-JAG, verified email, etc.).
-- `identity_assertion.credential_types_supported` — credential shapes available when registering with an assertion.
-- `events_supported` — security event schemas this service can ingest (currently revocation). Informational; you don't act on these directly.
+- `issuer` — the canonical issuer URL of this authorization server. Validate the `iss` claim of any token the AS signs against this.
+- `token_endpoint` — where you exchange a service-signed identity assertion for an access_token (Step 5).
+- `revocation_endpoint` — where you POST to revoke an access_token ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)).
+- `grant_types_supported` — confirms this AS accepts `urn:ietf:params:oauth:grant-type:jwt-bearer` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)) at `/oauth2/token`.
+- `agent_auth.skill` — the URL of this document.
+- `agent_auth.identity_endpoint` — where you POST to register (Step 3).
+- `agent_auth.claim_endpoint` — where you POST the claim invite and OTP (Step 4).
+- `agent_auth.revocation_uri` — where the provider POSTs a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) to notify the service of upstream identity events. You don't call this; it tells you what to expect.
+- `agent_auth.identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
+- `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts (ID-JAG, verified email, etc.).
+- `agent_auth.events_supported` — event schemas this service can ingest (currently revocation). Informational; you don't act on these directly.
 
 ## Step 2 — Pick a method
 
@@ -120,14 +124,13 @@ Mint the assertion with:
 - Near-term `exp` (~5 minutes)
 
 ```http
-POST /agent/auth
+POST /agent/identity
 Content-Type: application/json
 
 {
   "type": "identity_assertion",
   "assertion_type": "urn:ietf:params:oauth:token-type:id-jag",
-  "assertion": "<your ID-JAG JWT>",
-  "requested_credential_type": "access_token"
+  "assertion": "<your ID-JAG JWT>"
 }
 ```
 
@@ -137,26 +140,24 @@ Response (200):
 {
   "registration_id": "reg_...",
   "registration_type": "agent-provider",
-  "credential_type": "access_token",
-  "credential": "<token>",
-  "credential_expires": "2026-05-04T13:00:00.000Z",
-  "scopes": ["..."]
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "scopes": ["api.read", "api.write"]
 }
 ```
 
-Extract `credential`. Go to [Step 5](#step-5--use-the-credential).
+Keep `identity_assertion` and go to [Step 5](#step-5--exchange-the-assertion).
 
 ### identity_assertion + email
 
 ```http
-POST /agent/auth
+POST /agent/identity
 Content-Type: application/json
 
 {
   "type": "identity_assertion",
   "assertion_type": "verified_email",
-  "assertion": "user@example.com",
-  "requested_credential_type": "api_key"
+  "assertion": "user@example.com"
 }
 ```
 
@@ -166,25 +167,22 @@ Response (200):
 {
   "registration_id": "reg_...",
   "registration_type": "email-verification",
-  "claim_url": "https://auth.service.example.com/agent/auth/claim",
+  "claim_url": "https://auth.service.example.com/agent/identity/claim",
   "claim_token": "clm_...",
   "claim_token_expires": "2026-05-21T17:31:25.994Z",
   "post_claim_scopes": ["api.read", "api.write"]
 }
 ```
 
-There is no credential yet. The service has already emailed the user. Keep `claim_token` and go to [Step 4](#step-4--claim-ceremony). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
+No `identity_assertion` yet — the service has already emailed the user, and the assertion is minted on claim completion. Keep `claim_token` and go to [Step 4](#step-4--claim-ceremony). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
 
 ### anonymous
 
 ```http
-POST /agent/auth
+POST /agent/identity
 Content-Type: application/json
 
-{
-  "type": "anonymous",
-  "requested_credential_type": "api_key"
-}
+{ "type": "anonymous" }
 ```
 
 Response (200):
@@ -193,18 +191,17 @@ Response (200):
 {
   "registration_id": "reg_...",
   "registration_type": "anonymous",
-  "credential_type": "api_key",
-  "credential": "sk_test_...",
-  "credential_expires": null,
-  "scopes": ["api.read"],
-  "claim_url": "https://auth.service.example.com/agent/auth/claim",
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "pre_claim_scopes": ["api.read"],
+  "claim_url": "https://auth.service.example.com/agent/identity/claim",
   "claim_token": "clm_...",
   "claim_token_expires": "2026-05-21T17:26:32.915Z",
   "post_claim_scopes": ["api.read", "api.write"]
 }
 ```
 
-You have a usable credential immediately at pre-claim scopes. If you also want a human to take ownership and unlock `post_claim_scopes`, go to [Step 4](#step-4--claim-ceremony). Otherwise skip to [Step 5](#step-5--use-the-credential). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
+The `identity_assertion` exchanges at `/oauth2/token` for an access_token with `pre_claim_scopes` immediately. If you also want a human to take ownership and unlock `post_claim_scopes`, go to [Step 4](#step-4--claim-ceremony). Otherwise skip to [Step 5](#step-5--exchange-the-assertion). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
 
 ## Step 4 — Claim ceremony
 
@@ -215,7 +212,7 @@ The end goal: get the user to read a 6-digit OTP back to you.
 Skip this for `email` registrations — the email was sent during Step 3.
 
 ```http
-POST /agent/auth/claim
+POST /agent/identity/claim
 Content-Type: application/json
 
 {
@@ -246,7 +243,7 @@ The user receives an email, clicks the link, sees a 6-digit OTP, reads it back t
 ### 4c. Submit the OTP
 
 ```http
-POST /agent/auth/claim/complete
+POST /agent/identity/claim/complete
 Content-Type: application/json
 
 {
@@ -261,7 +258,7 @@ Response on success (anonymous):
 { "registration_id": "reg_...", "status": "claimed" }
 ```
 
-Your existing pre-claim API key keeps working — its scope set is upgraded in place. No new credential is issued.
+Re-run [Step 5](#step-5--exchange-the-assertion) with the same `identity_assertion` you already hold — the resulting access_token now carries the post-claim scope set.
 
 Response on success (email-verification):
 
@@ -269,60 +266,87 @@ Response on success (email-verification):
 {
   "registration_id": "reg_...",
   "status": "claimed",
-  "credential_type": "access_token",
-  "credential": "<token>",
-  "credential_expires": "...",
-  "scopes": ["..."]
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "..."
 }
 ```
 
-Extract `credential`.
+Keep the new `identity_assertion` and go to [Step 5](#step-5--exchange-the-assertion).
 
-## Step 5 — Use the credential
+## Step 5 — Exchange the assertion
 
-Whether `access_token` or `api_key`, present as a bearer token:
+POST the `identity_assertion` to the AS metadata's `token_endpoint` with the [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant. The `resource` parameter is optional but recommended — it pins the access_token to the API you're calling.
+
+```http
+POST /oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+&assertion=<identity_assertion>
+&resource=https://api.service.example.com/
+```
+
+Response (200):
+
+```json
+{
+  "access_token": "<token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "api.read api.write"
+}
+```
+
+Extract `access_token` and go to [Step 6](#step-6--use-the-access_token). The same `identity_assertion` can be re-used to mint additional access_tokens until it expires.
+
+If `/oauth2/token` returns `invalid_grant`, your `identity_assertion` is expired or revoked — restart at [Step 3](#step-3--register) to mint a fresh one.
+
+## Step 6 — Use the access_token
+
+Present the `access_token` as a bearer token:
 
 ```http
 GET /api/some-resource
-Authorization: Bearer <credential>
+Authorization: Bearer <access_token>
 ```
 
-- `access_token` from an ID-JAG: when it expires, mint a **fresh** ID-JAG and re-register. There is no refresh flow.
-- `access_token` from a claim ceremony: when it expires, re-run the ceremony or present a fresh assertion.
-- `api_key`: typically no expiry (`credential_expires: null`), but still subject to revocation.
+**Refresh.** When the access_token expires (`expires_in` seconds after issuance), re-call [Step 5](#step-5--exchange-the-assertion) with the same `identity_assertion`. When the identity assertion itself expires or `/oauth2/token` returns `invalid_grant`, restart at [Step 3](#step-3--register). There is no OAuth refresh_token in this flow — the two-step pattern replaces it.
 
-If you get a 401 on a previously-working credential: drop it, restart at [Step 1](#step-1--discover). Do not stash the credential and retry.
+If you get a 401 on a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once with the current assertion. If that also fails, drop everything and restart at [Step 1](#step-1--discover).
 
 Full API reference: `https://docs.service.example.com/`.
 
 ## Errors
 
-| Code                          | Where                        | What to do                                                                             |
-| ----------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| `invalid_signature`           | `/agent/auth` (ID-JAG)       | Signature didn't verify. Mint a fresh ID-JAG.                                          |
-| `replay_detected`             | `/agent/auth` (ID-JAG)       | `jti` already used. Mint a fresh ID-JAG with a new `jti`.                              |
-| `audience_mismatch`           | `/agent/auth` (ID-JAG)       | `aud` wrong. Mint with the correct `aud` (this service's AS base URL).                 |
-| `credential_expired`          | `/agent/auth` (ID-JAG)       | ID-JAG `exp` is past. Mint a fresh one.                                                |
-| `anonymous_not_enabled`       | `/agent/auth`                | This service doesn't accept anonymous. Pick another method from Step 2.                |
-| `verified_email_not_enabled`  | `/agent/auth`                | Email verification disabled here. Pick another method.                                 |
-| `issuer_not_enabled`          | `/agent/auth`                | Provider not on this service's trust list. Pick another method.                        |
-| `unsupported_credential_type` | `/agent/auth`                | Requested credential not supported for this method. Re-read AS metadata and adjust.    |
-| `rate_limited` (429)          | any                          | Back off and retry.                                                                    |
-| `invalid_claim_token`         | `/agent/auth/claim/complete` | `claim_token` wrong or expired. Restart at Step 3.                                     |
-| `otp_invalid`                 | `/agent/auth/claim/complete` | OTP mismatch. Ask the user to re-read the code.                                        |
-| `otp_expired`                 | `/agent/auth/claim/complete` | OTP window passed. Re-trigger the claim email (Step 4a) or restart at Step 3.          |
-| `claim_expired`               | `/agent/auth/claim/complete` | The whole registration expired. Restart at Step 3.                                     |
-| `previously_claimed`          | `/agent/auth/claim/complete` | Someone already finished this claim. Restart at Step 3 if you need a fresh credential. |
+Errors at `/agent/identity` and `/agent/identity/claim/*` use profile-specific codes (the registration ceremonies have no OAuth analog). Errors at `/oauth2/token` use OAuth-standard vocabulary per [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523).
+
+| Code                         | Where                            | What to do                                                                                                                                                             |
+| ---------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `anonymous_not_enabled`      | `/agent/identity`                | This service doesn't accept anonymous. Pick another method from Step 2.                                                                                                |
+| `verified_email_not_enabled` | `/agent/identity`                | Email verification disabled here. Pick another method.                                                                                                                 |
+| `issuer_not_enabled`         | `/agent/identity`                | Provider not on this service's trust list. Pick another method.                                                                                                        |
+| `invalid_request`            | `/agent/identity`                | Body shape, missing claims, ID-JAG signature/`jti`/`aud` problems, or unverified identity. Fix the input (mint a fresh ID-JAG if signature/`jti`/`aud`/`exp`-related). |
+| `invalid_claim_token`        | `/agent/identity/claim/complete` | `claim_token` wrong or expired. Restart at Step 3.                                                                                                                     |
+| `otp_invalid`                | `/agent/identity/claim/complete` | OTP mismatch. Ask the user to re-read the code.                                                                                                                        |
+| `otp_expired`                | `/agent/identity/claim/complete` | OTP window passed. Re-trigger the claim email (Step 4a) or restart at Step 3.                                                                                          |
+| `claim_expired`              | `/agent/identity/claim/complete` | The whole registration expired. Restart at Step 3.                                                                                                                     |
+| `previously_claimed`         | `/agent/identity/claim/complete` | Someone already finished this claim. Restart at Step 3 if you need a fresh assertion.                                                                                  |
+| `invalid_grant`              | `/oauth2/token`                  | Assertion expired, revoked, replayed, or otherwise failed verification. Restart at [Step 3](#step-3--register) to mint a fresh one.                                    |
+| `invalid_client`             | `/oauth2/token`                  | `client_id` not recognized. Re-read AS metadata.                                                                                                                       |
+| `unsupported_grant_type`     | `/oauth2/token`                  | `grant_type` must be `urn:ietf:params:oauth:grant-type:jwt-bearer`.                                                                                                    |
+| `rate_limited` (429)         | any                              | Back off and retry.                                                                                                                                                    |
 
 Retry policy:
 
 - 5xx → exponential backoff, retry the same request.
 - 4xx → do not retry the same payload; act on the table above.
-- 401 on a previously-working credential → drop the credential and restart at [Step 1](#step-1--discover).
+- 401 on a previously-working access_token → retry [Step 5](#step-5--exchange-the-assertion) once with the current assertion. If that fails, restart at [Step 1](#step-1--discover).
 
 ## Revocation
 
-You do not initiate revocation yourself. Two paths exist:
+Two independent layers can kill what you're holding:
 
-- **Provider-driven (ID-JAG flows)**: the provider that minted your ID-JAG can POST a `logout+jwt` to this service's `revocation_uri`. Your credential will be invalidated. You discover this on the next API call returning 401 — restart at [Step 1](#step-1--discover).
-- **Email / anonymous flows**: there is no agent-facing revoke endpoint. On a 401 for a previously-working credential, drop it and restart at Step 1.
+- **Credential layer ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009), `revocation_endpoint`)** — agent-callable. POST `token=<access_token>&token_type_hint=access_token` (form-encoded) to the top-level `revocation_endpoint` to kill one access_token. 200 on success, idempotent. Your `identity_assertion` is intact; re-run [Step 5](#step-5--exchange-the-assertion) to mint a fresh access_token.
+- **Registration layer (`agent_auth.revocation_uri`)** — provider-driven. The provider that minted your ID-JAG can POST a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) (`Content-Type: application/logout+jwt`) to this service's `revocation_uri`. The service invalidates the identity assertion and every access_token derived from it. You don't call this; you discover it the next time `/oauth2/token` returns `invalid_grant` — restart at [Step 3](#step-3--register).
+
+On a 401 for a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once. If `/oauth2/token` succeeds, the credential was revoked at the credential layer and your fresh access_token works. If `/oauth2/token` returns `invalid_grant`, the registration was killed at the registration layer — restart at [Step 3](#step-3--register).

--- a/AUTH.md
+++ b/AUTH.md
@@ -312,7 +312,7 @@ Authorization: Bearer <access_token>
 
 **Refresh.** When the access_token expires (`expires_in` seconds after issuance), re-call [Step 5](#step-5--exchange-the-assertion) with the same `identity_assertion`. When the identity assertion itself expires or `/oauth2/token` returns `invalid_grant`, restart at [Step 3](#step-3--register). There is no OAuth refresh_token in this flow — the two-step pattern replaces it.
 
-If you get a 401 on a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once with the current assertion. If that also fails, drop everything and restart at [Step 1](#step-1--discover).
+If you get a 401 on a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once with the current assertion. If that also fails, discard the expired identity assertion, and restart at [Step 1](#step-1--discover).
 
 Full API reference: `https://docs.service.example.com/`.
 

--- a/AUTH.md
+++ b/AUTH.md
@@ -299,7 +299,7 @@ Response (200):
 
 Extract `access_token` and go to [Step 6](#step-6--use-the-access_token). The same `identity_assertion` can be re-used to mint additional access_tokens until it expires.
 
-If `/oauth2/token` returns `invalid_grant`, your `identity_assertion` is expired or revoked — restart at [Step 3](#step-3--register) to mint a fresh one.
+If `/oauth2/token` returns `invalid_grant`, your `identity_assertion` is expired or revoked. Restart the flow at [Step 3](#step-3--register) to mint a fresh identity assertion.
 
 ## Step 6 — Use the access_token
 

--- a/AUTH.md
+++ b/AUTH.md
@@ -92,7 +92,7 @@ The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `toke
 - `agent_auth.skill` — the URL of this document.
 - `agent_auth.identity_endpoint` — where you POST to register (Step 3).
 - `agent_auth.claim_endpoint` — where you POST the claim invite and OTP (Step 4).
-- `agent_auth.revocation_uri` — where the provider POSTs a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) to notify the service of upstream identity events. You don't call this; it tells you what to expect.
+- `agent_auth.revocation_uri` — where the provider POSTs a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) to notify the service of upstream identity events.
 - `agent_auth.identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
 - `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts (ID-JAG, verified email, etc.).
 - `agent_auth.events_supported` — event schemas this service can ingest (currently revocation). Informational; you don't act on these directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# auth.md Changelog
+
+## v0.2.0 (2026-06-03)
+
+Separates the identity and credential surfaces. Registration now mints a service-signed `identity_assertion` that the agent exchanges for an access_token at a standard OAuth token endpoint, instead of having `/agent/auth` issue credentials directly. Aligns the access-token issuance, revocation, and discovery surfaces with the standards they were already adjacent to (RFC 7523, RFC 7009, RFC 8414, RFC 6749).
+
+### Added
+
+- `/oauth2/token` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant) — agents exchange the service-signed `identity_assertion` here for a short-lived `access_token`.
+- `/oauth2/revoke` ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)) — token revocation. Returns 200 for unknown or already-revoked tokens to prevent enumeration.
+- Service-side ES256 signing key for service-minted `identity_assertion`s; JWKS published at `/.well-known/jwks.json`.
+
+### Changed
+
+- `/agent/auth` renamed to `/agent/identity` (and claim sub-paths follow).
+- All three registration flows (anonymous, ID-JAG, verified-email) now return a service-signed `identity_assertion` instead of an access_token. Credentials are obtained by exchanging the assertion at `/oauth2/token`.
+- Discovery (`/.well-known/oauth-authorization-server`) surfaces the top-level [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) fields (`issuer`, `token_endpoint`, `revocation_endpoint`, `grant_types_supported`) alongside the existing `agent_auth` block. Inside `agent_auth`, `register_uri` / `claim_uri` are renamed to `identity_endpoint` / `claim_endpoint`.
+- Token-endpoint error responses follow the [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) envelope (`error` / `error_description`), and successful responses carry `Cache-Control: no-store` + `Pragma: no-cache` per [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
+- Anonymous registrations stay on pre-claim scopes for the full duration of the claim ceremony — previously the scope cap dropped as soon as the agent called `/agent/identity/claim`, before the user had confirmed ownership.
+
+### Removed
+
+- `requested_credential_type` parameter from all three identity flows. The credential surface is now a separate concern (`/oauth2/token`).
+
+
+## v0.1.0 (2026-05-21)
+
+Initial proposal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,15 @@ Separates the identity and credential surfaces. Registration now mints a service
 
 ### Changed
 
-- `/agent/auth` renamed to `/agent/identity` (and claim sub-paths follow).
+- `/agent/auth` renamed to `/agent/identity` (and sub-paths follow).
 - All three registration flows (anonymous, ID-JAG, verified-email) now return a service-signed `identity_assertion` instead of an access_token. Credentials are obtained by exchanging the assertion at `/oauth2/token`.
 - Discovery (`/.well-known/oauth-authorization-server`) surfaces the top-level [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) fields (`issuer`, `token_endpoint`, `revocation_endpoint`, `grant_types_supported`) alongside the existing `agent_auth` block. Inside `agent_auth`, `register_uri` / `claim_uri` are renamed to `identity_endpoint` / `claim_endpoint`.
 - Token-endpoint error responses follow the [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) envelope (`error` / `error_description`), and successful responses carry `Cache-Control: no-store` + `Pragma: no-cache` per [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
-- Anonymous registrations stay on pre-claim scopes for the full duration of the claim ceremony — previously the scope cap dropped as soon as the agent called `/agent/identity/claim`, before the user had confirmed ownership.
+- [bug fix] Anonymous registrations stay on pre-claim scopes for the full duration of the claim ceremony — previously the scope cap dropped as soon as the agent called `/agent/identity/claim`, before the user had confirmed ownership.
 
 ### Removed
 
 - `requested_credential_type` parameter from all three identity flows. The credential surface is now a separate concern (`/oauth2/token`).
-
 
 ## v0.1.0 (2026-05-21)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Service at <http://localhost:8000>, provider at <http://localhost:4000>. The ser
 
 ## System Flows
 
-Registration and credential issuance are split across two endpoints. `POST /agent/identity` accepts the agent's chosen identity proof (ID-JAG, verified email, or anonymous) and returns a service-signed `identity_assertion`. The agent then exchanges that assertion at `POST /oauth2/token` (RFC 7523 JWT-bearer grant) for an access_token.
+Registration and credential issuance are split across two endpoints. `POST /agent/identity` accepts the agent's chosen identity assertion (ID-JAG, verified email, or anonymous) and returns a service-signed `identity_assertion`. The agent then exchanges that assertion at `POST /oauth2/token` (RFC 7523 JWT-bearer grant) for an access_token.
 
 ### Discovery
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo includes sample implementations for both the agent provider and agent 
 
 ## Where to go next
 
-- **You're an agent or want an auth.md template** → [AUTH.md](AUTH.md) — procedural recipe (discover → register → claim → use → handle revoke).
+- **You're an agent or want an auth.md template** → [AUTH.md](AUTH.md) — procedural recipe (discover → register → claim → exchange → use → handle revoke).
 - **You're implementing a service** → [agent-services/README.md](agent-services/README.md) — full implementation guide, sequence diagrams, error tables.
 - **You're implementing an IdP** → [agent-providers/README.md](agent-providers/README.md) — minting ID-JAGs, publishing JWKS, sending revocation events.
 
@@ -31,7 +31,7 @@ Service at <http://localhost:8000>, provider at <http://localhost:4000>. The ser
 
 ## System Flows
 
-Three registration flows share the `/agent/auth` endpoint. Pick the one that matches what the agent has on hand.
+Registration and credential issuance are split across two endpoints. `POST /agent/identity` accepts the agent's chosen identity proof (ID-JAG, verified email, or anonymous) and returns a service-signed `identity_assertion`. The agent then exchanges that assertion at `POST /oauth2/token` (RFC 7523 JWT-bearer grant) for an access_token.
 
 ### Discovery
 
@@ -43,21 +43,23 @@ Hosted at `/.well-known/oauth-authorization-server`:
   "authorization_servers": ["https://auth.service.example.com/"],
   "scopes_supported": ["api.read", "api.write"],
   "bearer_methods_supported": ["header"],
+
+  "issuer": "https://auth.service.example.com",
+  "token_endpoint": "https://auth.service.example.com/oauth2/token",
+  "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
-    "register_uri": "https://auth.service.example.com/agent/auth",
-    "claim_uri": "https://auth.service.example.com/agent/auth/claim",
+    "identity_endpoint": "https://auth.service.example.com/agent/identity",
+    "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
     "identity_types_supported": ["anonymous", "identity_assertion"],
-    "anonymous": {
-      "credential_types_supported": ["api_key"]
-    },
     "identity_assertion": {
       "assertion_types_supported": [
         "urn:ietf:params:oauth:token-type:id-jag",
         "verified_email"
-      ],
-      "credential_types_supported": ["access_token", "api_key"]
+      ]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -65,6 +67,8 @@ Hosted at `/.well-known/oauth-authorization-server`:
   }
 }
 ```
+
+The top-level `issuer` / `token_endpoint` / `revocation_endpoint` / `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block is the profile extension carrying the registration and claim surface.
 
 ### Identity Assertion (ID-JAG)
 
@@ -89,11 +93,13 @@ sequenceDiagram
     Agent->>Provider: Request audience-specific ID-JAG
     Provider-->>Agent: 200 OK (ID-JAG)
 
-    Agent->>Service: POST /agent/auth<br/>{ type: identity_assertion, assertion: ID-JAG }
+    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion: ID-JAG }
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
-    Service->>Service: Verify signature + claims, match user
-    Service-->>Agent: 200 OK (credentials)
+    Service-->>Agent: 200 OK (identity_assertion)
+
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ### Verified-Email Identity Assertion
@@ -104,14 +110,16 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/auth<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
+    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
     Service->>User: Send claim-view email (one-time URL)
-    Service-->>Agent: 200 OK (claim_token, no credential)
-    User->>Service: GET /agent/auth/claim/view?token=...
+    Service-->>Agent: 200 OK (claim_token, no assertion yet)
+    User->>Service: GET /agent/identity/claim/view?token=...
     Service-->>User: 6-digit OTP page
     User-->>Agent: Reads OTP back
-    Agent->>Service: POST /agent/auth/claim/complete<br/>{ claim_token, otp }
-    Service-->>Agent: 200 OK (credential)
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, otp }
+    Service-->>Agent: 200 OK (identity_assertion)
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ### Anonymous Registration with OTP Claim
@@ -122,19 +130,21 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/auth<br/>{ type: anonymous, requested_credential_type: api_key }
-    Service->>Service: Create agent principal, scoped API key, claim record
-    Service-->>Agent: 200 OK (api_key, claim_token)
+    Agent->>Service: POST /agent/identity<br/>{ type: anonymous }
+    Service-->>Agent: 200 OK (identity_assertion, claim_token)
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token with pre-claim scope)
 
     Note over Agent: Agent operates with pre-claim scopes
 
     User-->>Agent: Wants to take ownership
-    Agent->>Service: POST /agent/auth/claim<br/>{ claim_token, email }
+    Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
     Service->>User: Send claim-view email (one-time URL)
-    User->>Service: GET /agent/auth/claim/view?token=...
+    User->>Service: GET /agent/identity/claim/view?token=...
     Service-->>User: 6-digit OTP page
     User-->>Agent: Reads OTP back
-    Agent->>Service: POST /agent/auth/claim/complete<br/>{ claim_token, otp }
-    Service->>Service: Swap API key perms (pre-claim → post-claim)
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, otp }
     Service-->>Agent: 200 OK { status: claimed }
+    Agent->>Service: POST /oauth2/token (re-exchange same assertion)
+    Service-->>Agent: 200 OK (access_token with post-claim scope)
 ```

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -96,7 +96,7 @@ Discovery is two-hop:
    }
    ```
 
-   The top-level `token_endpoint`, `revocation_endpoint`, and `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block carries the profile-specific bootstrap, claim, and revocation-receive endpoints.
+   The top-level `token_endpoint`, `revocation_endpoint`, and `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block carries the profile-specific bootstrap, claim, and revocation endpoints.
 
 ### Minting the Identity Assertion
 

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -29,10 +29,13 @@ sequenceDiagram
     Agent->>Provider: Request audience-specific ID-JAG
     Provider-->>Agent: 200 OK (ID-JAG)
 
-    Agent->>Service: POST /agent/auth<br/>{ type: identity_assertion, assertion: ID-JAG, credential_type }
+    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion: ID-JAG }
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
-    Service-->>Agent: 200 OK (credentials)
+    Service-->>Agent: 200 OK (identity_assertion)
+
+    Agent->>Service: POST /oauth2/token<br/>grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ## Minimum Agent Provider Implementation
@@ -68,21 +71,23 @@ Discovery is two-hop:
      "authorization_servers": ["https://auth.service.example.com/"],
      "scopes_supported": ["api.read", "api.write"],
      "bearer_methods_supported": ["header"],
+
+     "issuer": "https://auth.service.example.com",
+     "token_endpoint": "https://auth.service.example.com/oauth2/token",
+     "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
+     "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+
      "agent_auth": {
        "skill": "https://service.example.com/auth.md",
-       "register_uri": "https://auth.service.example.com/agent/auth",
-       "claim_uri": "https://auth.service.example.com/agent/auth/claim",
+       "identity_endpoint": "https://auth.service.example.com/agent/identity",
+       "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
        "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
        "identity_types_supported": ["anonymous", "identity_assertion"],
-       "anonymous": {
-         "credential_types_supported": ["api_key"]
-       },
        "identity_assertion": {
          "assertion_types_supported": [
            "urn:ietf:params:oauth:token-type:id-jag",
            "verified_email"
-         ],
-         "credential_types_supported": ["access_token", "api_key"]
+         ]
        },
        "events_supported": [
          "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -90,6 +95,8 @@ Discovery is two-hop:
      }
    }
    ```
+
+   The top-level `token_endpoint`, `revocation_endpoint`, and `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block carries the profile-specific bootstrap, claim, and revocation-receive endpoints.
 
 ### Minting the Identity Assertion
 
@@ -114,7 +121,6 @@ Discovery is two-hop:
 
   // optional
   "amr": ["mfa"],
-  "auth_time": <original auth epoch seconds>,
   "name": "Jane Smith",
 	"phone_number": "+15553805188",
 	"phone_number_verified": false,
@@ -146,70 +152,84 @@ In order for consuming services to verify the ID-JAG tokens, agent providers mus
 }
 ```
 
-### Acquiring Credentials
+### Acquiring an access_token
 
-Once the ID-JAG is minted, the agent can exchange it for service credentials:
+Exchanging an ID-JAG for an access_token is a two-step dance: the consuming service first issues its own service-signed identity assertion bound to the registration, then the agent exchanges that assertion at the OAuth token endpoint.
 
-```json
-POST /agent/auth HTTP/1.1
+**Step 1 — register the identity.** Submit the provider ID-JAG to the service's `identity_endpoint`:
+
+```http
+POST /agent/identity HTTP/1.1
 Host: auth.service.example.com
 Content-Type: application/json
 
-Payload:
 {
   "type": "identity_assertion",
   "assertion_type": "urn:ietf:params:oauth:token-type:id-jag",
-  "assertion": "eyJhbGc...",
-  "requested_credential_type": "<access_token | api_key>"
+  "assertion": "eyJhbGc..."
 }
-
-200 Response (access_token):
-{
-  "registration_id": "reg_...",
-  "registration_type": "agent-provider",
-  "credential_type": "access_token",
-  "credential": "<token>",
-  "credential_expires": "2026-05-04T13:00:00.000Z",
-  "scopes": ["api.read", "api.write"]
-}
-
-200 Response (api_key):
-{
-  "registration_id": "reg_...",
-  "registration_type": "agent-provider",
-  "credential_type": "api_key",
-  "credential": "sk_live_...",
-  "credential_expires": null,
-  "scopes": ["api.read", "api.write"]
-}
-
-400 Response:
-{ "error": "invalid_audience", "message": "..." }
 ```
 
-The spec supports both `access_token` and `api_key` credentials, with implementation up to the service.
+200 response — the service verified the ID-JAG, found or JIT-provisioned the user, and minted a service-signed `identity_assertion`:
 
-The ID-JAG spec specifies that access tokens returned from ID-JAG verification should not include a refresh token. If the agent wants to extend the life of its access token for a specific audience, it should follow the same flow to get a new credential.
+```json
+{
+  "registration_id": "reg_...",
+  "registration_type": "agent-provider",
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "scopes": ["api.read", "api.write"]
+}
+```
+
+**Step 2 — exchange the assertion at `/oauth2/token`.** Standard [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant:
+
+```http
+POST /oauth2/token HTTP/1.1
+Host: auth.service.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+&assertion=<service-signed identity_assertion>
+&resource=https://api.service.example.com/
+```
+
+200 response is a standard OAuth token envelope:
+
+```json
+{
+  "access_token": "<token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "api.read api.write"
+}
+```
+
+If the access_token expires, the agent re-calls `/oauth2/token` with the same identity assertion. If the assertion itself is expired or revoked, `/oauth2/token` returns `invalid_grant` and the agent re-calls `/agent/identity` to mint a fresh one. The ID-JAG flow does not issue OAuth refresh_tokens — the two-step pattern replaces refresh.
 
 #### Errors
 
-| Error code                         | Meaning                                                                                              |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `invalid_issuer`                   | Token `iss` isn't in the service's trusted providers list.                                           |
-| `invalid_signature`                | JWKS lookup failed or the signature didn't verify against any known key.                             |
-| `expired`                          | `exp` is in the past.                                                                                |
-| `replay_detected`                  | `jti` has already been seen within the replay window.                                                |
-| `invalid_audience`                 | `aud` doesn't match the service's auth server.                                                       |
-| `invalid_client_id`                | `client_id` doesn't resolve to a known provider identity.                                            |
-| `missing_verified_email`           | Neither `email_verified` nor `phone_number_verified` is `true`.                                      |
-| `unsupported_credential_type`      | Requested credential type isn't offered by the service.                                              |
-| `insufficient_user_authentication` | Auth context didn't meet policy ([RFC 9470](https://datatracker.ietf.org/doc/html/rfc9470) pattern). |
+Errors at `/agent/identity` describe profile-specific states; errors at `/oauth2/token` follow OAuth-standard vocabulary.
+
+| Endpoint          | Error code               | Meaning                                                                                                              |
+| ----------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `/agent/identity` | `invalid_issuer`         | Token `iss` isn't in the service's trusted providers list.                                                           |
+| `/agent/identity` | `invalid_signature`      | JWKS lookup failed or the signature didn't verify against any known key.                                             |
+| `/agent/identity` | `expired`                | `exp` is in the past.                                                                                                |
+| `/agent/identity` | `replay_detected`        | `jti` has already been seen within the replay window.                                                                |
+| `/agent/identity` | `invalid_audience`       | `aud` doesn't match the service's auth server.                                                                       |
+| `/agent/identity` | `invalid_client_id`      | `client_id` doesn't resolve to a known provider identity.                                                            |
+| `/agent/identity` | `missing_verified_email` | Neither `email_verified` nor `phone_number_verified` is `true`.                                                      |
+| `/agent/identity` | `invalid_request`        | Body shape, missing claims, or unverified identity (neither `email_verified` nor `phone_number_verified` is `true`). |
+| `/oauth2/token`   | `invalid_grant`          | Assertion failed verification, expired, replayed, audience-mismatched, or has been revoked.                          |
+| `/oauth2/token`   | `invalid_client`         | `client_id` doesn't resolve to a known provider identity.                                                            |
+| `/oauth2/token`   | `unsupported_grant_type` | `grant_type` is not `urn:ietf:params:oauth:grant-type:jwt-bearer`.                                                   |
 
 ## Downstream Verification
 
 Services will maintain a list of trusted agent providers. The service will attempt to match to an existing customer, looking for matches on `(iss, sub)` and then email/phone for JIT provisioning, and will determine whether to create a new account or permit using the identity assertion to return credentials for an existing account.
 
-Services will reject ID-JAGs with neither a verified email nor a verified phone number. If the service is satisfied by the validity of the identity assertion, it will return credentials of the requested type.
+Services will reject ID-JAGs with neither a verified email nor a verified phone number. If the service is satisfied by the validity of the identity assertion, it will return a service-signed identity assertion the agent can then exchange at `/oauth2/token` for an access_token.
 
 ## Tracking and Revocation
 

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -152,7 +152,7 @@ In order for consuming services to verify the ID-JAG tokens, agent providers mus
 }
 ```
 
-### Acquiring an access_token
+### Acquiring an access token
 
 Exchanging an ID-JAG for an access_token is a two-step dance: the consuming service first issues its own service-signed identity assertion bound to the registration, then the agent exchanges that assertion at the OAuth token endpoint.
 

--- a/agent-providers/src/routes/home.ts
+++ b/agent-providers/src/routes/home.ts
@@ -128,18 +128,12 @@ function renderHtml(seeded: { email: string; name: string }[]): string {
 </section>
 
 <section id="step-5" hidden>
-  <h2><span class="num">5</span>Exchange for credentials at consumer</h2>
-  <p>With a valid ID-JAG, the agent POSTs it to the consumer's <code>/agent/auth</code> endpoint. The consumer verifies the signature against <em>this</em> provider's JWKS and returns credentials for the matched user. Requires the consumer sample running at the audience URL.</p>
-  <label>Requested credential type
-    <select id="exchange-cred-type">
-      <option value="access_token">access_token</option>
-      <option value="api_key">api_key</option>
-    </select>
-  </label>
+  <h2><span class="num">5</span>Exchange at the consumer</h2>
+  <p>With a valid ID-JAG, the agent POSTs it to the consumer's <code>/agent/identity</code> endpoint. The consumer verifies the signature against <em>this</em> provider's JWKS and returns a service-signed <code>identity_assertion</code>. The agent then exchanges that assertion at the consumer's <code>/oauth2/token</code> (RFC 7523 JWT-bearer) for an access_token and calls <code>/api/resource</code>. Requires the consumer sample running at the audience URL.</p>
   <div class="label">Request</div>
   <div class="req" id="exchange-req"><pre></pre></div>
   <button class="primary" type="button" data-action="exchange">Exchange at consumer</button>
-  <button type="button" data-action="call-resource" id="call-resource" disabled>Call /api/resource with credential</button>
+  <button type="button" data-action="call-resource" id="call-resource" disabled>Call /api/resource with access_token</button>
   <div id="exchange-out"></div>
 </section>
 
@@ -255,19 +249,19 @@ function updateRevokePreview() {
 }
 function updateExchangePreview() {
   const aud = state.audience || document.getElementById("grant-audience").value;
-  const ct = document.getElementById("exchange-cred-type").value;
   const assertionHint = state.assertion ? state.assertion.slice(0, 40) + "..." : "eyJhbGc...";
   document.querySelector("#exchange-req pre").textContent =
-    "POST " + aud + "/agent/auth\\nContent-Type: application/json\\n\\n" + jsonStr({
+    "POST " + aud + "/agent/identity\\nContent-Type: application/json\\n\\n" + jsonStr({
       type: "identity_assertion",
       assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
       assertion: assertionHint,
-      requested_credential_type: ct,
-    });
+    }) +
+    "\\n\\nthen\\n\\n" +
+    "POST " + aud + "/oauth2/token\\nContent-Type: application/x-www-form-urlencoded\\n\\n" +
+    "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<service-signed assertion>";
 }
 document.querySelectorAll("#step-2 input, #step-2 select").forEach((el) => el.addEventListener("input", updateGrantPreview));
 document.querySelectorAll("#step-3 input").forEach((el) => el.addEventListener("input", updateMintPreview));
-document.getElementById("exchange-cred-type").addEventListener("change", updateExchangePreview);
 updateGrantPreview();
 updateMintPreview();
 updateRevokePreview();
@@ -367,23 +361,21 @@ async function verify() {
 }
 
 async function exchange() {
-  const ct = document.getElementById("exchange-cred-type").value;
-  const body = {
+  const identityBody = {
     type: "identity_assertion",
     assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
     assertion: state.assertion,
-    requested_credential_type: ct,
   };
-  let r;
+  let identityRes;
   try {
-    const resp = await fetch(state.audience + "/agent/auth", {
+    const resp = await fetch(state.audience + "/agent/identity", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
+      body: JSON.stringify(identityBody),
     });
     const text = await resp.text();
     let respBody; try { respBody = text ? JSON.parse(text) : ""; } catch { respBody = text; }
-    r = { status: resp.status, ok: resp.ok, body: respBody };
+    identityRes = { status: resp.status, ok: resp.ok, body: respBody };
   } catch (err) {
     document.getElementById("exchange-out").innerHTML =
       '<div class="label">fetch → FAIL</div>' +
@@ -392,10 +384,41 @@ async function exchange() {
       escapeHtml(err.message || String(err)) + '</pre></div>';
     return;
   }
-  document.getElementById("exchange-out").innerHTML = resBlock(r.status, r.body, r.ok);
-  if (!r.ok) return;
-  state.credential = r.body.access_token || r.body.api_key;
-  state.credentialType = r.body.type;
+  let html =
+    '<div class="label">POST /agent/identity → ' + identityRes.status + '</div>' +
+    '<div class="' + (identityRes.ok ? 'res' : 'res error') + '"><pre>' +
+    escapeHtml(jsonStr(identityRes.body)) + '</pre></div>';
+  document.getElementById("exchange-out").innerHTML = html;
+  if (!identityRes.ok) return;
+  state.serviceAssertion = identityRes.body.identity_assertion;
+
+  /* Now exchange the service-signed identity_assertion at /oauth2/token. */
+  const tokenParams = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.serviceAssertion,
+  });
+  let tokenRes;
+  try {
+    const resp = await fetch(state.audience + "/oauth2/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: tokenParams.toString(),
+    });
+    const text = await resp.text();
+    let respBody; try { respBody = text ? JSON.parse(text) : ""; } catch { respBody = text; }
+    tokenRes = { status: resp.status, ok: resp.ok, body: respBody };
+  } catch (err) {
+    document.getElementById("exchange-out").innerHTML +=
+      '<div class="label">POST /oauth2/token → FAIL</div>' +
+      '<div class="res error"><pre>' + escapeHtml(err.message || String(err)) + '</pre></div>';
+    return;
+  }
+  document.getElementById("exchange-out").innerHTML +=
+    '<div class="label">POST /oauth2/token → ' + tokenRes.status + '</div>' +
+    '<div class="' + (tokenRes.ok ? 'res' : 'res error') + '"><pre>' +
+    escapeHtml(jsonStr(tokenRes.body)) + '</pre></div>';
+  if (!tokenRes.ok) return;
+  state.credential = tokenRes.body.access_token;
   document.getElementById("call-resource").disabled = !state.credential;
   markDone("step-5");
   reveal("step-6");

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -1,14 +1,14 @@
 # Agent Auth Consumer Guide
 
-Services that want agents to authenticate on behalf of users — via Identity Assertion JWT Authorization Grants ([ID-JAGs](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-assertion-authz-grant)) from trusted providers, via a verified-email OTP ceremony, or via anonymous self-registration when no user identity is available — need to publish discovery metadata and implement the `/agent/auth` endpoints described here.
+Services that want agents to authenticate on behalf of users — via Identity Assertion JWT Authorization Grants ([ID-JAGs](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-assertion-authz-grant)) from trusted providers, via a verified-email OTP ceremony, or via anonymous self-registration when no user identity is available — need to publish discovery metadata and implement the `/agent/identity` registration endpoint and standard OAuth `/oauth2/token` and `/oauth2/revoke` endpoints described here.
 
 This guide covers three flows:
 
-1. **ID-JAG identity assertion** — trusted agent providers (OpenAI, Anthropic, Cursor, etc.) assert a user's identity with an ID-JAG. The service verifies the assertion and returns credentials for the matched user synchronously.
-2. **Verified-email identity assertion** — the agent gives us a user email; the service emails the user a one-time code, the user reads the code to the agent, the agent completes the claim and receives a credential.
-3. **Anonymous registration** — an agent with no user identity self-registers for scoped credentials and optionally invites a human to take ownership later via the same OTP ceremony.
+1. **ID-JAG identity assertion** — trusted agent providers (OpenAI, Anthropic, Cursor, etc.) assert a user's identity with an ID-JAG. The service verifies the assertion and returns a service-signed identity_assertion the agent exchanges at the token endpoint for an access_token.
+2. **Verified-email identity assertion** — the agent gives us a user email; the service emails the user a one-time code, the user reads the code to the agent, the agent completes the claim and receives an identity_assertion to exchange at the token endpoint.
+3. **Anonymous registration** — an agent with no user identity self-registers for a pre-claim identity_assertion and optionally invites a human to take ownership later via the same OTP ceremony.
 
-All three flows share the same `/agent/auth` registration endpoint. Verified-email and anonymous flows additionally use `/agent/auth/claim` and `/agent/auth/claim/complete` to drive the OTP exchange.
+All three flows share the same `/agent/identity` registration endpoint and terminate at `/oauth2/token` (RFC 7523 JWT-bearer) for credential issuance. Verified-email and anonymous flows additionally use `/agent/identity/claim` and `/agent/identity/claim/complete` to drive the OTP exchange.
 
 **Why adopt this.** ID-JAG is a near-drop-in if your service already JIT-provisions users via OIDC or SAML — it's standard JWT verification against a provider JWKS plus a delegation record per `(iss, sub, aud)`, with no user-model changes. The OTP flows are a real extension (a pre-claim principal state, a claim state machine, a scope-set swap) but they unlock MCP-server agents that start with no user identity — a use case nothing else handles cleanly. All three flows give users a real revoke surface for agent delegations, instead of copy-pasted API keys the service has no visibility into.
 
@@ -37,11 +37,14 @@ sequenceDiagram
     Agent->>Provider: Request audience-specific ID-JAG
     Provider-->>Agent: 200 OK (ID-JAG)
 
-    Agent->>Service: POST /agent/auth<br/>{ type: identity_assertion, assertion: ID-JAG }
+    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion: ID-JAG }
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
     Service->>Service: Verify signature + claims, match user
-    Service-->>Agent: 200 OK (credentials)
+    Service-->>Agent: 200 OK (identity_assertion)
+
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ### Anonymous Registration + OTP Claim
@@ -52,21 +55,23 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/auth<br/>{ type: anonymous, requested_credential_type: api_key }
-    Service->>Service: Create agent principal, scoped API key, claim record
-    Service-->>Agent: 200 OK (api_key, claim_token)
+    Agent->>Service: POST /agent/identity<br/>{ type: anonymous }
+    Service-->>Agent: 200 OK (identity_assertion, claim_token)
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token, pre-claim scope)
 
     Note over Agent: Agent operates with pre-claim scopes
 
     User-->>Agent: Wants to take ownership
-    Agent->>Service: POST /agent/auth/claim<br/>{ claim_token, email }
+    Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
     Service->>User: Send claim-view email (one-time URL)
-    User->>Service: GET /agent/auth/claim/view?token=...
+    User->>Service: GET /agent/identity/claim/view?token=...
     Service-->>User: 6-digit OTP page
     User-->>Agent: Reads OTP back
-    Agent->>Service: POST /agent/auth/claim/complete<br/>{ claim_token, otp }
-    Service->>Service: Swap API key perms (pre-claim → post-claim)
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, otp }
     Service-->>Agent: 200 OK { status: claimed }
+    Agent->>Service: POST /oauth2/token (re-exchange same assertion)
+    Service-->>Agent: 200 OK (access_token, post-claim scope)
 ```
 
 ### Verified-Email Identity Assertion
@@ -77,28 +82,31 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/auth<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
+    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
     Service->>User: Send claim-view email (one-time URL)
-    Service-->>Agent: 200 OK (claim_token, no credential)
-    User->>Service: GET /agent/auth/claim/view?token=...
+    Service-->>Agent: 200 OK (claim_token, no assertion yet)
+    User->>Service: GET /agent/identity/claim/view?token=...
     Service-->>User: 6-digit OTP page
     User-->>Agent: Reads OTP back
-    Agent->>Service: POST /agent/auth/claim/complete<br/>{ claim_token, otp }
-    Service-->>Agent: 200 OK (credential)
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, otp }
+    Service-->>Agent: 200 OK (identity_assertion)
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ## Minimum Consumer Implementation
 
 To participate as a consumer service, you should:
 
-1. Publish `.well-known/oauth-protected-resource` (resource + `authorization_servers`) and `.well-known/oauth-authorization-server` (carries the `agent_auth` block)
+1. Publish `.well-known/oauth-protected-resource` (resource + `authorization_servers`) and `.well-known/oauth-authorization-server` (top-level OAuth endpoints + `agent_auth` block)
 2. Return `WWW-Authenticate: Bearer resource_metadata="..."` on 401 responses
-3. Host a `/agent/auth` endpoint that dispatches on `type`
-4. Maintain a trust list of agent providers (for `identity_assertion`)
-5. Verify ID-JAG signatures against the provider's JWKS and enforce claim checks
-6. Issue credentials of the configured type (`access_token` or `api_key`)
-7. Accept revocation logout tokens at the advertised `revocation_uri`
-8. Record audit events for every state change in the flow
+3. Host `/agent/identity` (and its `/claim` sub-endpoints) that dispatches on `type` and returns a service-signed `identity_assertion`
+4. Host `/oauth2/token` (RFC 7523 JWT-bearer) that exchanges the `identity_assertion` for an access_token
+5. Host `/oauth2/revoke` (RFC 7009) for agent-initiated credential revocation
+6. Accept provider-initiated logout tokens at the advertised `revocation_uri`
+7. Maintain a trust list of agent providers (for `identity_assertion`)
+8. Verify ID-JAG signatures against the provider's JWKS and enforce claim checks
+9. Record audit events for every state change in the flow
 
 ### Publishing the Discovery Documents
 
@@ -128,21 +136,23 @@ AS metadata:
   "authorization_servers": ["https://auth.service.example.com/"],
   "scopes_supported": ["api.read", "api.write"],
   "bearer_methods_supported": ["header"],
+
+  "issuer": "https://auth.service.example.com",
+  "token_endpoint": "https://auth.service.example.com/oauth2/token",
+  "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
-    "register_uri": "https://auth.service.example.com/agent/auth",
-    "claim_uri": "https://auth.service.example.com/agent/auth/claim",
+    "identity_endpoint": "https://auth.service.example.com/agent/identity",
+    "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
     "identity_types_supported": ["anonymous", "identity_assertion"],
-    "anonymous": {
-      "credential_types_supported": ["api_key"]
-    },
     "identity_assertion": {
       "assertion_types_supported": [
         "urn:ietf:params:oauth:token-type:id-jag",
         "verified_email"
-      ],
-      "credential_types_supported": ["access_token", "api_key"]
+      ]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -150,6 +160,8 @@ AS metadata:
   }
 }
 ```
+
+Top-level `issuer` / `token_endpoint` / `revocation_endpoint` / `grant_types_supported` follow [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) (with `revocation_endpoint` per [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). The `agent_auth` block is a profile extension for the agent-auth–specific surface: the registration endpoint, the claim ceremony, and the revocation-receive endpoint.
 
 Advertise the identity types and assertion types your service accepts. Anonymous is the simplest if you only support self-registration; ID-JAG is for trusted-provider integrations; the verified email assertion type is for agents that have a user email but no provider-signed assertion.
 
@@ -162,12 +174,12 @@ WWW-Authenticate: Bearer resource_metadata="https://api.service.example.com/.wel
 
 Consider also publishing an `auth.md` at your root — a short, LLM-readable summary of your agent auth posture that points back at the PRM, for agents that discover via documentation rather than 401 probing.
 
-### Hosting the /agent/auth Endpoint
+### Hosting the /agent/identity Endpoint
 
-The endpoint dispatches on the `type` field. All requests scope to a single tenant / environment; how the service resolves that scope (hostname, bearer token, path prefix) is up to the implementation.
+The endpoint dispatches on the `type` field. All requests scope to a single tenant / environment; how the service resolves that scope (hostname, bearer token, path prefix) is up to the implementation. Every path through this endpoint returns a service-signed `identity_assertion` (a JWT with `typ: oauth-id-jag+jwt` and `sub = registration.id`) — never a credential. The agent exchanges that assertion at [`/oauth2/token`](#post-oauth2token--rfc-7523-jwt-bearer-grant) to obtain an access_token.
 
 ```http
-POST /agent/auth HTTP/1.1
+POST /agent/identity HTTP/1.1
 Host: auth.service.example.com
 Content-Type: application/json
 ```
@@ -180,8 +192,7 @@ Request:
 {
   "type": "identity_assertion",
   "assertion_type": "urn:ietf:params:oauth:token-type:id-jag",
-  "assertion": "eyJhbGc...",
-  "requested_credential_type": "access_token"
+  "assertion": "eyJhbGc..."
 }
 ```
 
@@ -193,35 +204,21 @@ Implementation steps:
 4. **Verify the signature** using the key matching `kid`.
 5. **Validate claims:** `aud` matches your auth server; `exp` is future; `iat` is not unreasonably future; `jti` has not been seen recently; `client_id` resolves to a known provider identity; at least one of `email_verified` or `phone_number_verified` is `true`.
 6. **Match or provision the user** (see [User Matching and JIT Provisioning](#user-matching-and-jit-provisioning)).
-7. **Issue credentials** of the requested type.
+7. **Mint a service-signed identity_assertion** (typed `oauth-id-jag+jwt`, signed by your AS key, with `sub` = the registration ID). This is what the agent will exchange at `/oauth2/token`.
 
-Successful response (`access_token`):
-
-```json
-{
-  "registration_id": "reg_...",
-  "registration_type": "agent-provider",
-  "credential_type": "access_token",
-  "credential": "<token>",
-  "credential_expires": "2026-05-04T13:00:00.000Z",
-  "scopes": ["api.read", "api.write"]
-}
-```
-
-Successful response (`api_key`):
+Successful response:
 
 ```json
 {
   "registration_id": "reg_...",
   "registration_type": "agent-provider",
-  "credential_type": "api_key",
-  "credential": "sk_live_...",
-  "credential_expires": null,
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z",
   "scopes": ["api.read", "api.write"]
 }
 ```
 
-Access tokens issued from ID-JAG verification must not include a refresh token — the spec requires the agent to present a fresh ID-JAG to extend access.
+The agent then POSTs the `identity_assertion` to [`/oauth2/token`](#post-oauth2token--rfc-7523-jwt-bearer-grant) to obtain an access_token. No credential is issued at `/agent/identity` itself.
 
 Error response (400):
 
@@ -229,23 +226,23 @@ Error response (400):
 { "error": "invalid_audience", "message": "..." }
 ```
 
-Supported error codes: `invalid_issuer`, `invalid_signature`, `expired`, `replay_detected`, `invalid_audience`, `invalid_client_id`, `missing_verified_email`, `unsupported_credential_type`, `insufficient_user_authentication` (RFC 9470 — auth context didn't meet policy).
+Supported error codes: `invalid_issuer`, `invalid_signature`, `expired`, `replay_detected`, `invalid_audience`, `invalid_client_id`, `missing_verified_email`.
 
 #### type: anonymous
 
 Request:
 
 ```json
-{ "type": "anonymous", "requested_credential_type": "api_key" }
+{ "type": "anonymous" }
 ```
 
 Implementation steps:
 
 1. Apply rate limits (see [Rate Limiting](#rate-limiting)).
-2. Create the principal that will own the credentials. The shape is up to the service — it might be a user, workspace, account, tenant, or organization. Flag it as agent-created so downstream events and UI can distinguish it.
-3. Issue an API key scoped to your configured pre-claim (untrusted) permissions.
-4. Generate a claim token (prefixed, high-entropy — e.g., `clm_` + 25 chars base62). Store only its SHA-256 hash. Return the plaintext exactly once.
-5. Schedule an expiration job at the registration's TTL to revoke the API key and mark the claim expired.
+2. Create the registration. The principal it eventually binds to is up to the service — it might be a user, workspace, account, tenant, or organization. Flag it as agent-created so downstream events and UI can distinguish it.
+3. Generate a claim token (prefixed, high-entropy — e.g., `clm_` + 25 chars base62). Store only its SHA-256 hash. Return the plaintext exactly once.
+4. Mint a service-signed `identity_assertion` bound to the registration. At `/oauth2/token` exchange time, unclaimed anonymous registrations get the pre-claim scope set.
+5. Schedule an expiration job at the registration's TTL to mark the claim expired.
 
 Successful response:
 
@@ -253,18 +250,17 @@ Successful response:
 {
   "registration_id": "reg_01ABC123DEF456GHI789JKL0MN",
   "registration_type": "anonymous",
-  "credential_type": "api_key",
-  "credential": "sk_test_abcdefghijklmnop123456789",
-  "credential_expires": null,
-  "scopes": ["api.read"],
-  "claim_url": "/agent/auth/claim",
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "pre_claim_scopes": ["api.read"],
+  "claim_url": "/agent/identity/claim",
   "claim_token": "clm_abc123def456ghi789jkl012mno",
   "claim_token_expires": "2026-04-22T12:34:56.789Z",
   "post_claim_scopes": ["api.read", "api.write"]
 }
 ```
 
-See [OTP Claim Flow](#otp-claim-flow) for `/agent/auth/claim` and `/agent/auth/claim/complete`.
+See [OTP Claim Flow](#otp-claim-flow) for `/agent/identity/claim` and `/agent/identity/claim/complete`. After a successful claim the agent re-exchanges the same `identity_assertion` at `/oauth2/token` to pick up the `post_claim_scopes`.
 
 #### type: identity_assertion (verified email)
 
@@ -274,17 +270,16 @@ Request:
 {
   "type": "identity_assertion",
   "assertion_type": "verified_email",
-  "assertion": "user@example.com",
-  "requested_credential_type": "api_key"
+  "assertion": "user@example.com"
 }
 ```
 
 Implementation steps:
 
-1. Create a registration row marked as `email-verification` and persist the asserted email and requested credential type.
+1. Create a registration row marked as `email-verification` and persist the asserted email.
 2. Generate a `claim_token` (returned to the agent) and a `claim_attempt_token` (delivered in the email link). Store SHA-256 hashes of both.
-3. Email the user a link to a server-rendered claim page. The page POSTs to [`/agent/auth/claim/attempt/challenge`](#post-agentauthclaimattemptchallenge--mint-the-otp-for-the-claim-page) to mint the OTP, which the user reads back to the agent.
-4. Return the claim handles — but **no credential**. Credentials are issued on `/agent/auth/claim/complete` once the OTP is verified.
+3. Email the user a link to a server-rendered claim page. The page POSTs to [`/agent/identity/claim/attempt/challenge`](#post-agentidentityclaimattemptchallenge--mint-the-otp-for-the-claim-page) to mint the OTP, which the user reads back to the agent.
+4. Return the claim handles — but **no identity_assertion**. The assertion is minted on `/agent/identity/claim/complete` once the OTP is verified.
 
 Successful response:
 
@@ -292,12 +287,74 @@ Successful response:
 {
   "registration_id": "reg_01ABC...",
   "registration_type": "email-verification",
-  "claim_url": "/agent/auth/claim",
+  "claim_url": "/agent/identity/claim",
   "claim_token": "clm_abc123...",
   "claim_token_expires": "2026-04-22T12:34:56.789Z",
   "post_claim_scopes": ["api.read", "api.write"]
 }
 ```
+
+### POST /oauth2/token — RFC 7523 JWT-bearer grant
+
+The agent presents the service-signed identity_assertion to exchange it for an access_token. Standard [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant, form-encoded:
+
+```
+POST /oauth2/token HTTP/1.1
+Host: auth.service.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+&assertion=<identity_assertion>
+&resource=https://api.service.example.com/
+```
+
+Implementation steps:
+
+1. **Parse the form-encoded body.** Validate `grant_type` is exactly `urn:ietf:params:oauth:grant-type:jwt-bearer`. Reject otherwise with `unsupported_grant_type`.
+2. **Verify the `assertion`** against your service's signing key. It must be `typ: "oauth-id-jag+jwt"`, with `iss` and `aud` equal to your AS, a valid `exp`, and a `sub` resolving to a registration in your store.
+3. **Look up the registration by `sub`.** If absent or expired, return `invalid_grant`.
+4. **Issue an access_token** scoped per the registration's state. Anonymous-unclaimed gets your configured pre-claim scopes; everything else gets the registration's full granted set.
+
+Successful response (standard OAuth shape per RFC 6749 §5.1):
+
+```json
+{
+  "access_token": "<token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "api.read api.write"
+}
+```
+
+No `registration_id` or `registration_type` on the token response — those identifiers live with the registration, not the credential. The same `identity_assertion` can be re-exchanged at `/oauth2/token` to refresh the access_token until the assertion itself expires.
+
+Error response uses standard OAuth error codes (RFC 6749 §5.2):
+
+```json
+{ "error": "invalid_grant", "error_description": "..." }
+```
+
+Supported error codes: `invalid_request`, `invalid_grant`, `unsupported_grant_type`.
+
+### POST /oauth2/revoke — RFC 7009 token revocation
+
+The agent (or an admin via back-channel) POSTs the access_token to revoke:
+
+```
+POST /oauth2/revoke HTTP/1.1
+Host: auth.service.example.com
+Content-Type: application/x-www-form-urlencoded
+
+token=<access_token>&token_type_hint=access_token
+```
+
+Implementation:
+
+- Mark the credential revoked. 200 OK on success, no body. Idempotent.
+- Return 200 even when the token is unknown or already revoked ([RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) — prevents enumeration).
+- Return 400 with `{ "error": "invalid_request", "error_description": "..." }` only when the body itself is malformed.
+
+The agent's `identity_assertion` is unaffected — they can immediately re-call `/oauth2/token` to mint a fresh access_token. To kill the underlying registration, the provider uses the legacy logout-token mechanism at `revocation_uri` (see [Revocation](#revocation)).
 
 ### Verifying ID-JAGs
 
@@ -328,14 +385,14 @@ Reject ID-JAGs with neither a verified email nor a verified phone — there's no
 
 Both `anonymous` and `verified_email` flows funnel into the same OTP ceremony. The difference is _when_ the email is sent and _what_ `/complete` returns:
 
-| Flow           | Email sent at                | `/complete` returns                                                       |
-| -------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| Anonymous      | `/agent/auth/claim`          | `{ status: "claimed" }` only — existing API key's scopes upgrade in place |
-| Verified-email | `/agent/auth` (registration) | `{ status: "claimed", credential, ... }` — fresh credential issued        |
+| Flow           | Email sent at                    | `/complete` returns                                                                      |
+| -------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| Anonymous      | `/agent/identity/claim`          | `{ status: "claimed" }` only — agent re-exchanges existing assertion for upgraded scopes |
+| Verified-email | `/agent/identity` (registration) | `{ status: "claimed", identity_assertion, ... }` — fresh assertion issued                |
 
-#### POST /agent/auth/claim — Anonymous claim entry
+#### POST /agent/identity/claim — Anonymous claim entry
 
-Anonymous-only. Verified-email registrations skip this step — their email is sent at `/agent/auth` already.
+Anonymous-only. Verified-email registrations skip this step — their email is sent at `/agent/identity` already.
 
 Request:
 
@@ -357,16 +414,16 @@ Response (200):
 }
 ```
 
-`claim_attempt_id` identifies the current claim attempt. A new identifier is minted each time a fresh attempt is initiated at `/agent/auth/claim` — including retries with the same email after a prior attempt expired. `registration_id` stays stable for the lifetime of the registration.
+`claim_attempt_id` identifies the current claim attempt. A new identifier is minted each time a fresh attempt is initiated at `/agent/identity/claim` — including retries with the same email after a prior attempt expired. `registration_id` stays stable for the lifetime of the registration.
 
 Implementation notes:
 
 - Hash the incoming `claim_token` and look up the registration. Reject if not found (`invalid_claim_token`), already claimed (`claimed_or_in_flight`), or expired (`claim_expired`).
 - Mint a `claim_attempt_token`, store its SHA-256 hash, and email the user a link that includes the plaintext token.
-- The link lands on a service-hosted page. The page POSTs the `claim_attempt_token` to [`/agent/auth/claim/attempt/challenge`](#post-agentauthclaimattemptchallenge--mint-the-otp-for-the-claim-page) to mint and display the OTP, which the user reads back to the agent.
+- The link lands on a service-hosted page. The page POSTs the `claim_attempt_token` to [`/agent/identity/claim/attempt/challenge`](#post-agentidentityclaimattemptchallenge--mint-the-otp-for-the-claim-page) to mint and display the OTP, which the user reads back to the agent.
 - Communicate to the user that an agent is requesting ownership, and make it easy to reject if unrecognized.
 
-#### POST /agent/auth/claim/attempt/challenge — Mint the OTP for the claim page
+#### POST /agent/identity/claim/attempt/challenge — Mint the OTP for the claim page
 
 Called by the user's browser when it renders the claim page, **not by the agent**. The user lands on the service's claim page from the email link; the page POSTs the `claim_attempt_token` (from the URL) to this endpoint to mint a short-lived OTP and display it.
 
@@ -399,7 +456,7 @@ Errors:
 
 Calling this endpoint again on the same registration mints a fresh OTP and invalidates the prior one — so a page refresh rotates the code.
 
-#### POST /agent/auth/claim/complete — Finish the ceremony
+#### POST /agent/identity/claim/complete — Finish the ceremony
 
 The agent collects the OTP from the user and finishes the claim:
 
@@ -419,21 +476,21 @@ Response (200) for verified-email:
 {
   "registration_id": "reg_01ABC...",
   "status": "claimed",
-  "credential_type": "access_token",
-  "credential": "...",
-  "credential_expires": "2026-05-04T13:00:00.000Z",
-  "scopes": ["api.read", "api.write"]
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z"
 }
 ```
+
+The agent then exchanges the `identity_assertion` at `/oauth2/token` for an access_token.
 
 Implementation notes:
 
 - Hash both the `claim_token` and the OTP, compare to stored hashes. Reject with `otp_invalid` (401), `otp_expired` (410), `previously_claimed` (409), or `claim_expired` (410).
-- For anonymous: link the existing credential to the matched/JIT'd user, replace its scope set with `post_claim_scopes`, and don't rotate the token. Agents keep the same key.
-- For verified-email: issue a fresh credential of the type requested at registration (`access_token` or `api_key`).
+- For anonymous: link the registration to the matched/JIT'd user. Any access_tokens already issued from this registration's identity_assertion are upgraded in place to `post_claim_scopes` — the agent keeps using the same access_token, now with wider scope. No fresh identity_assertion is issued (the registration's original assertion is still valid).
+- For verified-email: mint a fresh service-signed identity_assertion and return it. The agent exchanges it at `/oauth2/token` for its first access_token.
 - Emit `claim.confirmed` (see [Recommended Audit Events](#recommended-audit-events)).
 
-**Why in-place permission swap on anonymous?** The agent doesn't need to handle a rotation flow or poll for a new key, there's no race window between claim confirmation and the agent discovering it needs to re-exchange, and it's consistent with how most permission systems (IAM, RBAC, database grants, GitHub PATs) operate. The trade-off is that any party who captured the key value pre-claim retains access post-claim with the new scopes. For higher-security tenants, offer a forced-rotation opt-in.
+**Why in-place permission swap on anonymous?** The agent doesn't need to handle a rotation flow or poll for a new key, there's no race window between claim confirmation and the agent discovering it needs to re-exchange, and it's consistent with how most permission systems (IAM, RBAC, database grants, GitHub PATs) operate. The trade-off is that any party who captured the access_token pre-claim retains access post-claim with the new scopes. For higher-security tenants, offer a forced-rotation opt-in.
 
 ### Revocation
 
@@ -469,7 +526,7 @@ In a future state, expect to extend this surface with [SET](https://datatracker.
 
 ### Rate Limiting
 
-The `/agent/auth` endpoint is unauthenticated for anonymous registration and accepts bearer ID-JAGs for identity assertion. Both paths benefit from two-tier rate limiting, checked in order:
+The `/agent/identity` endpoint is unauthenticated for anonymous registration and accepts bearer ID-JAGs for identity assertion. Both paths benefit from two-tier rate limiting, checked in order:
 
 1. **Per-IP limit** (checked first). Prevents a single source from consuming the tenant's budget. Sensible default: 5/hour for anonymous, 60/hour for identity_assertion.
 2. **Per-tenant limit** (checked second). Global cap across IPs. Sensible default: 100/hour anonymous, 1000/hour identity_assertion.
@@ -480,14 +537,17 @@ Use a sliding-window counter backed by a shared store (Redis is common). Fail op
 
 Record the following state transitions for observability and incident response. How they're exposed — audit log, webhook, SIEM stream, admin API — is an implementation choice; the set of events and the data they carry is the useful baseline.
 
-| Event                  | When                                                    | Recommended fields                      |
-| ---------------------- | ------------------------------------------------------- | --------------------------------------- |
-| `registration.created` | Any successful `/agent/auth` POST                       | `registration_id`, `registration_type`  |
-| `claim.requested`      | `/agent/auth/claim` called (or implicit on email-verif) | `registration_id`, `email`              |
-| `otp.generated`        | OTP minted for the claim view                           | `registration_id`                       |
-| `claim.confirmed`      | `/agent/auth/claim/complete` succeeds                   | `registration_id`, `claimed_by_user_id` |
-| `registration.expired` | Unclaimed registration past its TTL                     | `registration_id`                       |
-| `registration.revoked` | Logout token processed                                  | `registration_id`, `iss`, `sub`         |
+| Event                  | When                                                        | Recommended fields                      |
+| ---------------------- | ----------------------------------------------------------- | --------------------------------------- |
+| `registration.created` | Any successful `/agent/identity` POST                       | `registration_id`, `registration_type`  |
+| `assertion.issued`     | A service-signed identity_assertion is minted               | `registration_id`                       |
+| `token.issued`         | `/oauth2/token` returns an access_token                     | `registration_id`, `scope`              |
+| `token.revoked`        | `/oauth2/revoke` invalidates a credential                   | `registration_id`                       |
+| `claim.requested`      | `/agent/identity/claim` called (or implicit on email-verif) | `registration_id`, `email`              |
+| `otp.generated`        | OTP minted for the claim view                               | `registration_id`                       |
+| `claim.confirmed`      | `/agent/identity/claim/complete` succeeds                   | `registration_id`, `claimed_by_user_id` |
+| `registration.expired` | Unclaimed registration past its TTL                         | `registration_id`                       |
+| `registration.revoked` | Logout token processed                                      | `registration_id`, `iss`, `sub`         |
 
 For ID-JAG flows, include `iss`, `sub`, `agent_platform`, and `agent_context_id` so operators can correlate with provider-side logs.
 
@@ -495,11 +555,11 @@ Services that already expose resource events (for API keys, invitations, members
 
 ## Security Considerations
 
-- **Token hashing.** The `claim_token`, `claim_attempt_token`, and OTP are all bearer secrets with no proof of possession — store only SHA-256 hashes. Plaintext leaves the server exactly once: claim_token in the `/agent/auth` response, claim_attempt_token in the email link, OTP on the user-facing view page.
+- **Token hashing.** The `claim_token`, `claim_attempt_token`, and OTP are all bearer secrets with no proof of possession — store only SHA-256 hashes. Plaintext leaves the server exactly once: claim_token in the `/agent/identity` response, claim_attempt_token in the email link, OTP on the user-facing view page.
 - **OTP entropy + TTL.** Use a CSPRNG (`crypto.randomInt`) for the OTP. Default to a short TTL (≤10 min) and tight per-claim retry limits — 6-digit codes are guess-bounded only by lockout, not entropy.
 - **IP logging.** Capture IPs at registration, claim, and complete for audit trail.
 - **Scope on /claim and /complete.** Both endpoints are public but must resolve to a tenant / environment, and reject tokens that don't belong to that scope even if the hash somehow collides.
 - **Key reuse across the claim boundary.** For anonymous, the in-place permission swap means anyone who captured the API key pre-claim retains access post-claim with the new scopes. Offer forced rotation as an opt-in for security-sensitive tenants.
 - **Bulk revocation.** Provide an operator-facing mechanism to revoke all outstanding agent credentials for a tenant in one shot — for incident response.
-- **Assertion replay.** Cache `jti` values for at least the assertion lifetime plus clock skew. A shared store is required if `/agent/auth` runs across multiple replicas.
+- **Assertion replay.** Cache `jti` values for at least the assertion lifetime plus clock skew. A shared store is required if `/agent/identity` runs across multiple replicas.
 - **Trust list discipline.** Treat the trusted-providers list as security-critical configuration. Changes should be audited and rolled out with the same care as any auth config change.

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -326,7 +326,7 @@ Successful response (standard OAuth shape per RFC 6749 §5.1):
 }
 ```
 
-No `registration_id` or `registration_type` on the token response — those identifiers live with the registration, not the credential. The same `identity_assertion` can be re-exchanged at `/oauth2/token` to refresh the access_token until the assertion itself expires.
+The token endpoint should never issue a `refresh_token`. The same `identity_assertion` can be re-exchanged at `/oauth2/token` to refresh the access_token until the assertion itself expires.
 
 Error response uses standard OAuth error codes (RFC 6749 §5.2):
 

--- a/agent-services/src/config.ts
+++ b/agent-services/src/config.ts
@@ -13,11 +13,28 @@ export const config = Object.freeze({
   preClaimScopes: ["api.read"],
   postClaimScopes: ["api.read", "api.write"],
   accessTokenTtlSeconds: 3600,
+  /**
+   * Lifetime of service-signed identity_assertions returned by /agent/identity.
+   * Agents re-exchange the assertion at /oauth2/token to refresh access_tokens
+   * within this window; when it expires, the agent re-calls /agent/identity.
+   */
+  serviceAssertionTtlSeconds: 3600,
   anonymousTtlSeconds: 86400,
   claimViewTokenTtlSeconds: 600,
   otpTtlSeconds: 600,
   clockSkewSeconds: 60,
+  /** RFC 7523 JWT-bearer grant endpoint. */
+  tokenEndpointPath: "/oauth2/token",
+  /** RFC 7009 token revocation endpoint. */
+  revocationEndpointPath: "/oauth2/revoke",
+  /** Agent identity-assertion endpoint (profile extension). */
+  identityEndpointPath: "/agent/identity",
+  /** Claim ceremony endpoint, nested under identity. */
+  claimEndpointPath: "/agent/identity/claim",
+  /** Legacy logout-token receiver path. */
+  revocationUriPath: "/agent/auth/revoke",
   corsOrigins: [providerUrl],
   mailDir: ".mail",
   mailUrlPath: "/mail",
+  keyPath: ".keys/signing-key.json",
 });

--- a/agent-services/src/index.ts
+++ b/agent-services/src/index.ts
@@ -1,11 +1,13 @@
 import cors from "cors";
 import express from "express";
 import { config } from "./config.js";
+import { initKeys } from "./keys.js";
 import { agentAuthRouter } from "./routes/agent-auth.js";
 import { apiRouter } from "./routes/api.js";
 import { authMdRouter } from "./routes/auth-md.js";
 import { homeRouter } from "./routes/home.js";
 import { mailRouter } from "./routes/mail.js";
+import { tokenRouter } from "./routes/token.js";
 import { wellKnownRouter } from "./routes/well-known.js";
 
 function accessLog(
@@ -24,6 +26,8 @@ function accessLog(
 }
 
 async function main() {
+  await initKeys();
+
   const app = express();
   app.use(cors({ origin: config.corsOrigins }));
   app.use(express.json());
@@ -34,6 +38,7 @@ async function main() {
   app.use(authMdRouter);
   app.use(mailRouter);
   app.use(agentAuthRouter);
+  app.use(tokenRouter);
   app.use(apiRouter);
 
   app.use(

--- a/agent-services/src/keys.ts
+++ b/agent-services/src/keys.ts
@@ -1,0 +1,97 @@
+import {
+  type JWK,
+  type KeyLike,
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+  importJWK,
+} from "jose";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { config } from "./config.js";
+
+const ALG = "ES256";
+
+type KeyState = {
+  privateKey: KeyLike;
+  publicJwk: JWK;
+  kid: string;
+};
+
+let state: KeyState | null = null;
+
+async function loadFromDisk(): Promise<JWK | null> {
+  try {
+    const raw = await readFile(config.keyPath, "utf8");
+    return JSON.parse(raw) as JWK;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+async function persist(privateJwk: JWK): Promise<void> {
+  await mkdir(dirname(config.keyPath), { recursive: true });
+  await writeFile(config.keyPath, JSON.stringify(privateJwk, null, 2), {
+    mode: 0o600,
+  });
+}
+
+export async function initKeys(): Promise<void> {
+  let privateJwk = await loadFromDisk();
+  if (!privateJwk) {
+    const { privateKey } = await generateKeyPair(ALG, { extractable: true });
+    privateJwk = await exportJWK(privateKey);
+    privateJwk.alg = ALG;
+    privateJwk.use = "sig";
+    await persist(privateJwk);
+  }
+
+  const privateKey = (await importJWK(privateJwk, ALG)) as KeyLike;
+  const publicJwk: JWK = {
+    kty: privateJwk.kty,
+    crv: privateJwk.crv,
+    x: privateJwk.x,
+    y: privateJwk.y,
+    alg: ALG,
+    use: "sig",
+  };
+  const kid = await calculateJwkThumbprint(publicJwk);
+  publicJwk.kid = kid;
+
+  state = { privateKey, publicJwk, kid };
+  console.log(`[keys] loaded ES256 signing key, kid=${kid}`);
+}
+
+function requireState(): KeyState {
+  if (!state) throw new Error("keys not initialized — call initKeys() first");
+  return state;
+}
+
+export function getPublicJwk(): JWK {
+  return requireState().publicJwk;
+}
+
+export function getKid(): string {
+  return requireState().kid;
+}
+
+export async function signServiceJwt(
+  payload: Record<string, unknown>,
+  typ: string,
+  ttlSeconds: number,
+): Promise<{ jwt: string; expiresAt: Date }> {
+  const { privateKey, kid } = requireState();
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+  const jwt = await new SignJWT(payload)
+    .setProtectedHeader({ alg: ALG, kid, typ })
+    .setIssuedAt()
+    .setExpirationTime(`${ttlSeconds}s`)
+    .sign(privateKey);
+  return { jwt, expiresAt };
+}
+
+export async function getPrivateKey(): Promise<KeyLike> {
+  return requireState().privateKey;
+}

--- a/agent-services/src/keys.ts
+++ b/agent-services/src/keys.ts
@@ -15,6 +15,7 @@ const ALG = "ES256";
 
 type KeyState = {
   privateKey: KeyLike;
+  publicKey: KeyLike;
   publicJwk: JWK;
   kid: string;
 };
@@ -59,8 +60,9 @@ export async function initKeys(): Promise<void> {
   };
   const kid = await calculateJwkThumbprint(publicJwk);
   publicJwk.kid = kid;
+  const publicKey = (await importJWK(publicJwk, ALG)) as KeyLike;
 
-  state = { privateKey, publicJwk, kid };
+  state = { privateKey, publicKey, publicJwk, kid };
   console.log(`[keys] loaded ES256 signing key, kid=${kid}`);
 }
 
@@ -94,4 +96,8 @@ export async function signServiceJwt(
 
 export async function getPrivateKey(): Promise<KeyLike> {
   return requireState().privateKey;
+}
+
+export async function getPublicKey(): Promise<KeyLike> {
+  return requireState().publicKey;
 }

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -11,30 +11,34 @@ import {
   parseBody,
 } from "../schemas.js";
 import {
-  type Registration,
   completeClaim,
   createAnonymousRegistration,
   createEmailVerificationRegistration,
-  credentials,
+  findOrCreateIdJagRegistration,
   findRegistrationByClaimHash,
   findRegistrationByClaimViewHash,
   generateOtpForRegistration,
-  issueAccessToken,
-  issueApiKey,
   recordAnonymousClaimAttempt,
   revokeForDelegation,
   sha256Hex,
 } from "../store.js";
-import { verifyIdJag, verifyLogoutJwt } from "../verify.js";
+import { signServiceIdJag, verifyIdJag, verifyLogoutJwt } from "../verify.js";
 
-// Agent-facing endpoints implementing the OTP-exchange flavor of the
-// agent-auth spec. The user-facing /agent/auth/claim/view endpoint at the
-// bottom of this file is also part of the spec — it's where the email link
-// lands and where the OTP is rendered.
+/*
+ * Agent-facing endpoints implementing the OTP-exchange flavor of the
+ * agent-auth spec. The user-facing /agent/identity/claim/view endpoint at the
+ * bottom of this file is also part of the spec — it's where the email link
+ * lands and where the OTP is rendered.
+ *
+ * All three flows (anonymous, identity_assertion+id_jag, identity_assertion+
+ * email) terminate by returning a service-signed identity_assertion. The
+ * agent then exchanges that assertion at /oauth2/token (RFC 7523 JWT-bearer)
+ * for an access_token. No credentials are issued here.
+ */
 
 export const agentAuthRouter = Router();
 
-agentAuthRouter.post("/agent/auth", async (req, res) => {
+agentAuthRouter.post(config.identityEndpointPath, async (req, res) => {
   const parsed = parseBody(agentAuthBody, req.body);
   if (!parsed.ok) {
     res.status(400).json({ error: "invalid_request", message: parsed.message });
@@ -48,33 +52,26 @@ agentAuthRouter.post("/agent/auth", async (req, res) => {
     return handleIdJagAssertion(parsed.value, res);
   }
 
-  // type === "anonymous"
-  const { registration, credential, claimTokenPlaintext } =
-    createAnonymousRegistration({
-      requestedCredentialType: parsed.value.requested_credential_type,
-    });
+  const { registration, claimTokenPlaintext } = createAnonymousRegistration();
+  const { jwt, expiresAt } = await signServiceIdJag({ registration });
   console.log(
     `[agent-auth] registered anonymous agent registration=${registration.id}`,
   );
   res.json({
     registration_id: registration.id,
     registration_type: "anonymous",
-    credential_type: "api_key",
-    credential: credential.token,
-    credential_expires: credential.expires_at?.toISOString() ?? null,
-    scopes: credential.scope,
-    claim_url: `${config.baseUrl}/agent/auth/claim`,
+    identity_assertion: jwt,
+    assertion_expires: expiresAt.toISOString(),
+    pre_claim_scopes: config.preClaimScopes,
+    claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
     claim_token: claimTokenPlaintext,
-    claim_token_expires: registration.expires_at.toISOString(),
+    claim_token_expires: registration.claim!.expires_at.toISOString(),
     post_claim_scopes: config.postClaimScopes,
   });
 });
 
 async function handleIdJagAssertion(
-  body: {
-    assertion: string;
-    requested_credential_type: "access_token" | "api_key";
-  },
+  body: { assertion: string },
   res: express.Response,
 ): Promise<void> {
   const verified = await verifyIdJag(body.assertion);
@@ -86,76 +83,55 @@ async function handleIdJagAssertion(
   }
   const { claims } = verified;
   const { user } = matchOrProvision(claims);
-  const scope = config.scopesSupported;
 
-  const registrationId = `reg_${sha256Hex(`${claims.iss}|${claims.sub}|${claims.aud}`).slice(0, 22)}`;
-
-  if (body.requested_credential_type === "api_key") {
-    const cred = issueApiKey({
-      userId: user.id,
-      scope,
-      source: "identity_assertion",
-      iss: claims.iss,
-      sub: claims.sub,
-      aud: claims.aud,
-    });
-    console.log(
-      `[agent-auth] issued api_key to user=${user.id} via iss=${claims.iss} sub=${claims.sub}`,
-    );
-    res.json({
-      registration_id: registrationId,
-      registration_type: "agent-provider",
-      credential_type: "api_key",
-      credential: cred.token,
-      credential_expires: cred.expires_at?.toISOString() ?? null,
-      scopes: scope,
-    });
-    return;
-  }
-
-  const cred = issueAccessToken({
-    userId: user.id,
-    scope,
-    source: "identity_assertion",
+  /*
+   * Ensure a registration exists for this (iss, sub, aud) so future
+   * credential lifecycle (revocation, audit, /token refresh) has a durable
+   * identity to anchor to. Idempotent across repeat presentations.
+   */
+  const registration = findOrCreateIdJagRegistration({
     iss: claims.iss,
     sub: claims.sub,
     aud: claims.aud,
+    userId: user.id,
+  });
+
+  const { jwt, expiresAt } = await signServiceIdJag({
+    registration,
+    email: claims.email,
+    emailVerified: claims.email_verified,
+    amr: claims.amr,
   });
   console.log(
-    `[agent-auth] issued access_token to user=${user.id} via iss=${claims.iss} sub=${claims.sub}`,
+    `[agent-auth] issued identity_assertion to user=${user.id} via iss=${claims.iss} sub=${claims.sub} registration=${registration.id}`,
   );
   res.json({
-    registration_id: registrationId,
+    registration_id: registration.id,
     registration_type: "agent-provider",
-    credential_type: "access_token",
-    credential: cred.token,
-    credential_expires: cred.expires_at?.toISOString() ?? null,
-    scopes: scope,
+    identity_assertion: jwt,
+    assertion_expires: expiresAt.toISOString(),
+    scopes: config.scopesSupported,
   });
 }
 
 async function handleEmailAssertion(
-  body: {
-    assertion: string;
-    requested_credential_type: "access_token" | "api_key";
-  },
+  body: { assertion: string },
   res: express.Response,
 ): Promise<void> {
   const { registration, claimTokenPlaintext, claimViewTokenPlaintext } =
-    createEmailVerificationRegistration({
-      email: body.assertion,
-      requestedCredentialType: body.requested_credential_type,
-    });
+    createEmailVerificationRegistration({ email: body.assertion });
 
-  // Email-verification registrations bundle the claim ceremony — we send
-  // the OTP-view email immediately. The agent skips /agent/auth/claim and
-  // polls /complete with the OTP the user reads back.
-  const viewUrl = `${config.baseUrl}/agent/auth/claim/view?token=${encodeURIComponent(claimViewTokenPlaintext)}`;
+  /*
+   * Email-verification registrations bundle the claim ceremony — we send
+   * the OTP-view email immediately. The agent skips /agent/identity/claim
+   * and polls /complete with the OTP the user reads back.
+   */
+  const viewUrl = `${config.baseUrl}${config.claimEndpointPath}/view?token=${encodeURIComponent(claimViewTokenPlaintext)}`;
   await sendClaimViewEmail({
     registrationId: registration.id,
     recipientEmail: body.assertion,
     viewUrl,
-    expiresAt: registration.claim_view_expires_at!,
+    expiresAt: registration.claim!.attempt!.view_expires_at,
   });
 
   console.log(
@@ -165,16 +141,18 @@ async function handleEmailAssertion(
   res.json({
     registration_id: registration.id,
     registration_type: "email-verification",
-    claim_url: `${config.baseUrl}/agent/auth/claim`,
+    claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
     claim_token: claimTokenPlaintext,
-    claim_token_expires: registration.expires_at.toISOString(),
+    claim_token_expires: registration.claim!.expires_at.toISOString(),
     post_claim_scopes: config.postClaimScopes,
   });
 }
 
-// Anonymous-only entry point. Email-verification registrations skip this —
-// their claim attempt is created in /agent/auth itself.
-agentAuthRouter.post("/agent/auth/claim", async (req, res) => {
+/*
+ * Anonymous-only entry point. Email-verification registrations skip this —
+ * their claim attempt is created in /agent/identity itself.
+ */
+agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   const parsed = parseBody(claimBody, req.body);
   if (!parsed.ok) {
     res.status(400).json({ error: "invalid_request", message: parsed.message });
@@ -198,12 +176,7 @@ agentAuthRouter.post("/agent/auth/claim", async (req, res) => {
     });
     return;
   }
-  if (registration.expires_at.getTime() < Date.now()) {
-    registration.status = "expired";
-    if (registration.credential_token) {
-      const cred = credentials.get(registration.credential_token);
-      if (cred) cred.revoked = true;
-    }
+  if (registration.status === "expired") {
     res
       .status(410)
       .json({ error: "claim_expired", message: "Registration has expired." });
@@ -217,21 +190,24 @@ agentAuthRouter.post("/agent/auth/claim", async (req, res) => {
     return;
   }
 
-  // Idempotent: if a claim attempt is already in flight (same email, view
-  // window still open), echo current state without resending the email. A
-  // same-email retry after the view window expires falls through and mints
-  // a fresh attempt below.
+  /*
+   * Idempotent: if a claim attempt is already in flight (same email, view
+   * window still open), echo current state without resending the email. A
+   * same-email retry after the view window expires falls through and mints
+   * a fresh attempt below.
+   */
+  const inflight = registration.claim?.attempt;
   if (
     registration.status === "pending_claim" &&
-    registration.claim_email === parsed.value.email &&
-    registration.claim_view_expires_at &&
-    registration.claim_view_expires_at.getTime() > Date.now()
+    registration.claim?.email === parsed.value.email &&
+    inflight &&
+    inflight.view_expires_at.getTime() > Date.now()
   ) {
     res.json({
       registration_id: registration.id,
-      claim_attempt_id: registration.claim_attempt_id!,
+      claim_attempt_id: inflight.id,
       status: "initiated",
-      expires_at: registration.claim_view_expires_at.toISOString(),
+      expires_at: inflight.view_expires_at.toISOString(),
     });
     return;
   }
@@ -240,12 +216,13 @@ agentAuthRouter.post("/agent/auth/claim", async (req, res) => {
     registration,
     parsed.value.email,
   );
-  const viewUrl = `${config.baseUrl}/agent/auth/claim/view?token=${encodeURIComponent(claimViewTokenPlaintext)}`;
+  const attempt = registration.claim!.attempt!;
+  const viewUrl = `${config.baseUrl}${config.claimEndpointPath}/view?token=${encodeURIComponent(claimViewTokenPlaintext)}`;
   await sendClaimViewEmail({
     registrationId: registration.id,
     recipientEmail: parsed.value.email,
     viewUrl,
-    expiresAt: registration.claim_view_expires_at!,
+    expiresAt: attempt.view_expires_at,
   });
 
   console.log(
@@ -254,85 +231,119 @@ agentAuthRouter.post("/agent/auth/claim", async (req, res) => {
 
   res.json({
     registration_id: registration.id,
-    claim_attempt_id: registration.id,
+    claim_attempt_id: attempt.id,
     status: "initiated",
-    expires_at: registration.claim_view_expires_at!.toISOString(),
+    expires_at: attempt.view_expires_at.toISOString(),
   });
 });
 
-// Exchanges a claim_attempt_token for an OTP.
-agentAuthRouter.post("/agent/auth/claim/attempt/challenge", (req, res) => {
-  const parsed = parseBody(generateOtpBody, req.body);
-  if (!parsed.ok) {
-    res.status(400).json({ error: "invalid_request", message: parsed.message });
-    return;
-  }
-  const registration = findRegistrationByClaimViewHash(
-    sha256Hex(parsed.value.claim_attempt_token),
-  );
-  if (!registration) {
-    res.status(410).json({
-      error: "claim_superseded",
-      message: "The claim attempt token is invalid or has been superseded.",
+/* Exchanges a claim_attempt_token for an OTP. */
+agentAuthRouter.post(
+  `${config.claimEndpointPath}/attempt/challenge`,
+  (req, res) => {
+    const parsed = parseBody(generateOtpBody, req.body);
+    if (!parsed.ok) {
+      res
+        .status(400)
+        .json({ error: "invalid_request", message: parsed.message });
+      return;
+    }
+    const registration = findRegistrationByClaimViewHash(
+      sha256Hex(parsed.value.claim_attempt_token),
+    );
+    if (!registration) {
+      res.status(410).json({
+        error: "claim_superseded",
+        message: "The claim attempt token is invalid or has been superseded.",
+      });
+      return;
+    }
+    if (registration.status === "claimed") {
+      res
+        .status(409)
+        .json({ error: "claim_completed", message: "Already claimed." });
+      return;
+    }
+    const attempt = registration.claim?.attempt;
+    if (!attempt || attempt.view_expires_at.getTime() < Date.now()) {
+      res
+        .status(410)
+        .json({ error: "claim_expired", message: "Claim window has closed." });
+      return;
+    }
+    const { otp, expiresAt } = generateOtpForRegistration(registration);
+    console.log(
+      `[agent-auth] generated otp for registration=${registration.id}`,
+    );
+    res.json({
+      type: "otp",
+      challenge: otp,
+      expires_at: expiresAt.toISOString(),
     });
-    return;
-  }
-  if (registration.status === "claimed") {
-    res
-      .status(409)
-      .json({ error: "claim_completed", message: "Already claimed." });
-    return;
-  }
-  if (
-    !registration.claim_view_expires_at ||
-    registration.claim_view_expires_at.getTime() < Date.now()
-  ) {
-    res
-      .status(410)
-      .json({ error: "claim_expired", message: "Claim window has closed." });
-    return;
-  }
-  const { otp, expiresAt } = generateOtpForRegistration(registration);
-  console.log(`[agent-auth] generated otp for registration=${registration.id}`);
-  res.json({
-    type: "otp",
-    challenge: otp,
-    expires_at: expiresAt.toISOString(),
-  });
-});
+  },
+);
 
-agentAuthRouter.post("/agent/auth/claim/complete", (req, res) => {
-  const parsed = parseBody(claimCompleteBody, req.body);
-  if (!parsed.ok) {
-    res.status(400).json({ error: "invalid_request", message: parsed.message });
-    return;
-  }
-  const registration = findRegistrationByClaimHash(
-    sha256Hex(parsed.value.claim_token),
-  );
-  if (!registration) {
-    res.status(401).json({
-      error: "invalid_claim_token",
-      message: "The claim token is invalid.",
+agentAuthRouter.post(
+  `${config.claimEndpointPath}/complete`,
+  async (req, res) => {
+    const parsed = parseBody(claimCompleteBody, req.body);
+    if (!parsed.ok) {
+      res
+        .status(400)
+        .json({ error: "invalid_request", message: parsed.message });
+      return;
+    }
+    const registration = findRegistrationByClaimHash(
+      sha256Hex(parsed.value.claim_token),
+    );
+    if (!registration) {
+      res.status(401).json({
+        error: "invalid_claim_token",
+        message: "The claim token is invalid.",
+      });
+      return;
+    }
+
+    const result = completeClaim(registration, parsed.value.otp);
+    if (!result.ok) {
+      const status = pickStatusForCompleteError(result.error);
+      res.status(status).json({
+        error: result.error,
+        message: humanCompleteError(result.error),
+      });
+      return;
+    }
+
+    console.log(
+      `[agent-auth] claim completed for registration=${result.registration.id}`,
+    );
+
+    /*
+     * Anonymous: no fresh assertion — the original is still valid; the agent
+     * re-exchanges it at /oauth2/token to pick up the upgraded post-claim
+     * scope set on its access_token.
+     *
+     * Email-verification: mint a fresh service-signed identity_assertion the
+     * agent exchanges at /oauth2/token for its first access_token.
+     */
+    if (result.registration.kind === "anonymous") {
+      res.json({ registration_id: result.registration.id, status: "claimed" });
+      return;
+    }
+
+    const { jwt, expiresAt } = await signServiceIdJag({
+      registration: result.registration,
+      email: result.user.email,
+      emailVerified: true,
     });
-    return;
-  }
-
-  const result = completeClaim(registration, parsed.value.otp);
-  if (!result.ok) {
-    const status = pickStatusForCompleteError(result.error);
-    res
-      .status(status)
-      .json({ error: result.error, message: humanCompleteError(result.error) });
-    return;
-  }
-
-  console.log(
-    `[agent-auth] claim completed for registration=${result.registration.id}`,
-  );
-
-  res.json(buildCompleteResponse(result.registration, result.credential));
-});
+    res.json({
+      registration_id: result.registration.id,
+      status: "claimed",
+      identity_assertion: jwt,
+      assertion_expires: expiresAt.toISOString(),
+    });
+  },
+);
 
 function pickStatusForCompleteError(error: string): number {
   switch (error) {
@@ -367,32 +378,14 @@ function humanCompleteError(error: string): string {
   }
 }
 
-function buildCompleteResponse(
-  registration: Registration,
-  credential: ReturnType<typeof issueApiKey> | undefined,
-): Record<string, unknown> {
-  const base: Record<string, unknown> = {
-    registration_id: registration.id,
-    status: "claimed",
-  };
-  // Only email-verification registrations receive a fresh credential at
-  // /complete. Anonymous registrations get an in-place scope upgrade on
-  // their existing API key — same key, wider scopes.
-  if (credential && registration.kind === "email_verification") {
-    base.credential_type = credential.type;
-    base.credential = credential.token;
-    base.credential_expires = credential.expires_at?.toISOString() ?? null;
-    base.scopes = credential.scope;
-  }
-  return base;
-}
-
-// User-facing OTP-view page. The email link lands here; the page gates
-// OTP minting behind an explicit user click that POSTs to
-// /agent/auth/claim/attempt/challenge. In production this page is typically
-// gated by a user session to handle edge cases (like updating the email on
-// the claim) upfront instead of in the agent context.
-agentAuthRouter.get("/agent/auth/claim/view", async (req, res) => {
+/*
+ * User-facing OTP-view page. The email link lands here; the page gates
+ * OTP minting behind an explicit user click that POSTs to
+ * /agent/identity/claim/attempt/challenge. In production this page is
+ * typically gated by a user session to handle edge cases (like updating the
+ * email on the claim) upfront instead of in the agent context.
+ */
+agentAuthRouter.get(`${config.claimEndpointPath}/view`, async (req, res) => {
   const rawToken = req.query.token;
   const token = typeof rawToken === "string" ? rawToken : "";
   if (!token) {
@@ -437,10 +430,8 @@ agentAuthRouter.get("/agent/auth/claim/view", async (req, res) => {
       );
     return;
   }
-  if (
-    !registration.claim_view_expires_at ||
-    registration.claim_view_expires_at.getTime() < Date.now()
-  ) {
+  const attempt = registration.claim?.attempt;
+  if (!attempt || attempt.view_expires_at.getTime() < Date.now()) {
     res
       .status(410)
       .type("html")
@@ -464,7 +455,7 @@ agentAuthRouter.get("/agent/auth/claim/view", async (req, res) => {
       renderClaimViewPage({
         ok: true,
         title: "Read this code back to the agent",
-        message: `The agent will ask you for a one-time code to confirm you're the owner of <code>${escapeHtml(registration.claim_email ?? "")}</code>. Read the code below back to the agent — do not share it with anyone else.`,
+        message: `The agent will ask you for a one-time code to confirm you're the owner of <code>${escapeHtml(registration.claim?.email ?? "")}</code>. Read the code below back to the agent — do not share it with anyone else.`,
         claimAttemptToken: token,
       }),
     );
@@ -477,6 +468,7 @@ function renderClaimViewPage(input: {
   claimAttemptToken?: string;
 }): string {
   const headingColor = input.ok ? "var(--brand-primary)" : "var(--error)";
+  const challengeUrl = `${config.claimEndpointPath}/attempt/challenge`;
   const otpBlock = input.claimAttemptToken
     ? `
 <div class="otp-wrap">
@@ -488,7 +480,7 @@ function renderClaimViewPage(input: {
   var otpOut = document.getElementById("otp-out");
   var errOut = document.getElementById("error-out");
   var token = ${JSON.stringify(input.claimAttemptToken)};
-  fetch("/agent/auth/claim/attempt/challenge", {
+  fetch(${JSON.stringify(challengeUrl)}, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ claim_attempt_token: token }),
@@ -563,7 +555,7 @@ function escapeHtml(s: string): string {
 }
 
 agentAuthRouter.post(
-  "/agent/auth/revoke",
+  config.revocationUriPath,
   express.text({ type: "application/logout+jwt" }),
   async (req, res) => {
     const token = typeof req.body === "string" ? req.body.trim() : "";

--- a/agent-services/src/routes/api.ts
+++ b/agent-services/src/routes/api.ts
@@ -17,7 +17,6 @@ apiRouter.get("/api/resource", requireCredential, (req, res) => {
         }
       : null,
     credential: {
-      type: credential.type,
       scope: credential.scope,
       source: credential.source,
       iss: credential.iss,

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -103,7 +103,7 @@ function renderHtml(): string {
 
 <section id="step-2" hidden>
   <h2><span class="num">2</span>Discovery</h2>
-  <p>Following the hint from the 401, the agent fetches <code>/.well-known/oauth-protected-resource</code>. The PRM advertises an <code>authorization_servers</code> entry; the agent then fetches the standard <code>/.well-known/oauth-authorization-server</code> at that server for the <code>agent_auth</code> block describing supported registration flows.</p>
+  <p>Following the hint from the 401, the agent fetches <code>/.well-known/oauth-protected-resource</code>. The PRM advertises an <code>authorization_servers</code> entry; the agent then fetches the standard <code>/.well-known/oauth-authorization-server</code> at that server. The <code>agent_auth</code> block describes the registration surface; the top-level <code>token_endpoint</code> and <code>revocation_endpoint</code> are standard OAuth 2.0.</p>
   <div class="label">Request</div>
   <div class="req"><pre>GET /.well-known/oauth-protected-resource</pre></div>
   <button class="primary" type="button" data-action="discover-prm">Fetch PRM</button>
@@ -124,26 +124,35 @@ function renderHtml(): string {
 
 <section id="step-3" class="track-anon" hidden>
   <h2><span class="num">3</span>Register anonymously</h2>
-  <p>An agent without a user identity POSTs <code>{ "type": "anonymous", "requested_credential_type": "api_key" }</code>. The service issues an api_key with pre-claim scopes and returns a claim_token for the human-handoff ceremony.</p>
+  <p>An agent without a user identity POSTs <code>{ "type": "anonymous" }</code> to <code>/agent/identity</code>. The service returns a service-signed <code>identity_assertion</code> bound to the new registration plus a <code>claim_token</code> for the human-handoff ceremony.</p>
   <div class="label">Request</div>
-  <div class="req"><pre>POST /agent/auth
+  <div class="req"><pre>POST /agent/identity
 Content-Type: application/json
 
-{ "type": "anonymous", "requested_credential_type": "api_key" }</pre></div>
+{ "type": "anonymous" }</pre></div>
   <button class="primary" type="button" data-action="anon-register">Register</button>
   <div id="anon-register-out"></div>
 </section>
 
 <section id="step-4" class="track-anon" hidden>
-  <h2><span class="num">4</span>Call with the pre-claim api_key</h2>
-  <p>The api_key works immediately, but only with the scopes configured for unclaimed registrations (here: <code>api.read</code>).</p>
+  <h2><span class="num">4</span>Exchange the assertion for a pre-claim access_token</h2>
+  <p>The agent POSTs the <code>identity_assertion</code> to <code>/oauth2/token</code> with the RFC 7523 JWT-bearer grant type. The response is a standard OAuth token envelope; the <code>scope</code> reflects the unclaimed pre-claim scope set.</p>
+  <div class="label">Request</div>
+  <div class="req" id="anon-exchange-req"><pre></pre></div>
+  <button class="primary" type="button" data-action="anon-exchange">Exchange at /oauth2/token</button>
+  <div id="anon-exchange-out"></div>
+</section>
+
+<section id="step-5" class="track-anon" hidden>
+  <h2><span class="num">5</span>Call with the pre-claim access_token</h2>
+  <p>The access_token works immediately, but only with the scopes configured for unclaimed registrations (here: <code>api.read</code>).</p>
   <button class="primary" type="button" data-action="anon-call-pre">Call /api/resource</button>
   <div id="anon-pre-out"></div>
 </section>
 
-<section id="step-5" class="track-anon" hidden>
-  <h2><span class="num">5</span>Send the claim email</h2>
-  <p>The agent invites a human to take ownership. <code>POST /agent/auth/claim</code> records the request and sends an email containing a <code>claim_attempt_token</code> URL (written to <code>agent-services/.mail/&lt;registration_id&gt;.html</code>, served at <code>/mail/&lt;registration_id&gt;.html</code>).</p>
+<section id="step-6" class="track-anon" hidden>
+  <h2><span class="num">6</span>Send the claim email</h2>
+  <p>The agent invites a human to take ownership. <code>POST /agent/identity/claim</code> records the request and sends an email containing a one-time URL (written to <code>agent-services/.mail/&lt;registration_id&gt;.html</code>, served at <code>/mail/&lt;registration_id&gt;.html</code>).</p>
   <label>Claiming user email
     <input id="anon-claim-email" value="alice@example.com">
   </label>
@@ -153,15 +162,15 @@ Content-Type: application/json
   <div id="anon-claim-out"></div>
 </section>
 
-<section id="step-6" class="track-anon" hidden>
-  <h2><span class="num">6</span>User opens the email and reads the OTP</h2>
-  <p>The user clicks the link in the email and lands on <code>/agent/auth/claim/view</code>. The page POSTs the <code>claim_attempt_token</code> to <code>/agent/auth/claim/attempt/challenge</code>, which mints a 6-digit OTP that the page displays. They read the code back to the agent.</p>
+<section id="step-7" class="track-anon" hidden>
+  <h2><span class="num">7</span>User opens the email and reads the OTP</h2>
+  <p>The user clicks the link and lands on <code>/agent/identity/claim/view</code>. The page POSTs the attempt token to <code>/agent/identity/claim/attempt/challenge</code>, which mints a 6-digit OTP. They read the code back to the agent.</p>
   <div id="anon-mail-link"></div>
 </section>
 
-<section id="step-7" class="track-anon" hidden>
-  <h2><span class="num">7</span>Complete the claim</h2>
-  <p>The agent POSTs the OTP it heard from the user to <code>/agent/auth/claim/complete</code>. The pre-claim api_key keeps working — its scopes are upgraded in place.</p>
+<section id="step-8" class="track-anon" hidden>
+  <h2><span class="num">8</span>Complete the claim</h2>
+  <p>The agent POSTs the OTP to <code>/agent/identity/claim/complete</code>. No fresh credential is issued; the registration's scopes are upgraded in place.</p>
   <label>OTP from user
     <input id="anon-otp" class="otp" placeholder="123456" maxlength="6">
   </label>
@@ -171,10 +180,10 @@ Content-Type: application/json
   <div id="anon-complete-out"></div>
 </section>
 
-<section id="step-8" class="track-anon" hidden>
-  <h2><span class="num">8</span>Call with the post-claim api_key</h2>
-  <p>Same key, wider scope. The credential's <code>user_id</code> is now linked to the claiming user — before claim it had no user binding at all.</p>
-  <button class="primary" type="button" data-action="anon-call-post">Call /api/resource</button>
+<section id="step-9" class="track-anon" hidden>
+  <h2><span class="num">9</span>Re-exchange to pick up post-claim scopes</h2>
+  <p>The agent re-runs the JWT-bearer exchange with the same identity_assertion. The resulting access_token now carries the full post-claim scope set.</p>
+  <button class="primary" type="button" data-action="anon-call-post">Re-exchange and call</button>
   <div id="anon-post-out"></div>
 </section>
 
@@ -183,9 +192,9 @@ Content-Type: application/json
 <div class="track">
 <p class="track-header email" id="track-b-header" hidden>Track B — Email-verification registration</p>
 
-<section id="step-9" class="track-email" hidden>
-  <h2><span class="num">9</span>Register with an email assertion</h2>
-  <p>The agent already has the user's email but no provider-signed assertion. It POSTs <code>/agent/auth</code> with <code>assertion_type: verified_email</code>. The service mails the user immediately and returns a claim_token, but no credential yet.</p>
+<section id="step-10" class="track-email" hidden>
+  <h2><span class="num">10</span>Register with an email assertion</h2>
+  <p>The agent has the user's email but no provider-signed assertion. It POSTs <code>/agent/identity</code> with <code>assertion_type: verified_email</code>. The service mails the user immediately and returns a claim_token, but no assertion yet — the agent has to claim first.</p>
   <label>User email
     <input id="email-assertion" value="alice@example.com">
   </label>
@@ -195,15 +204,15 @@ Content-Type: application/json
   <div id="email-register-out"></div>
 </section>
 
-<section id="step-10" class="track-email" hidden>
-  <h2><span class="num">10</span>User opens the email and reads the OTP</h2>
+<section id="step-11" class="track-email" hidden>
+  <h2><span class="num">11</span>User opens the email and reads the OTP</h2>
   <p>Same OTP page as Track A — the user reads the 6-digit code back to the agent.</p>
   <div id="email-mail-link"></div>
 </section>
 
-<section id="step-11" class="track-email" hidden>
-  <h2><span class="num">11</span>Complete the claim, receive a credential</h2>
-  <p>The agent POSTs the OTP to <code>/agent/auth/claim/complete</code>. Unlike anonymous, this is when the credential is issued — the registration response had no key.</p>
+<section id="step-12" class="track-email" hidden>
+  <h2><span class="num">12</span>Complete the claim, receive an identity_assertion</h2>
+  <p>Posting the OTP to <code>/agent/identity/claim/complete</code> mints a fresh service-signed identity_assertion for the now-bound user.</p>
   <label>OTP from user
     <input id="email-otp" class="otp" placeholder="123456" maxlength="6">
   </label>
@@ -213,9 +222,10 @@ Content-Type: application/json
   <div id="email-complete-out"></div>
 </section>
 
-<section id="step-12" class="track-email" hidden>
-  <h2><span class="num">12</span>Call /api/resource with the new credential</h2>
-  <button class="primary" type="button" data-action="email-call">Call /api/resource</button>
+<section id="step-13" class="track-email" hidden>
+  <h2><span class="num">13</span>Exchange the assertion and call</h2>
+  <p>The agent POSTs the identity_assertion to <code>/oauth2/token</code> for an access_token, then calls <code>/api/resource</code>.</p>
+  <button class="primary" type="button" data-action="email-call">Exchange and call</button>
   <div id="email-call-out"></div>
 </section>
 
@@ -224,32 +234,35 @@ Content-Type: application/json
 <div class="track">
 <p class="track-header ia" id="track-c-header" hidden>Track C — ID-JAG identity assertion</p>
 
-<section id="step-13" hidden>
-  <h2><span class="num">13</span>Exchange an ID-JAG for credentials</h2>
-  <p>Paste an ID-JAG minted by the provider (run the <a href="${providerHint}" target="_blank">provider demo</a> through step 5, then copy the <code>assertion</code> value). The consumer verifies the signature against the provider's JWKS, enforces replay protection, and matches or provisions a user.</p>
+<section id="step-14" hidden>
+  <h2><span class="num">14</span>Exchange an ID-JAG for an identity_assertion</h2>
+  <p>Paste an ID-JAG minted by the provider (run the <a href="${providerHint}" target="_blank">provider demo</a> through its exchange step, then copy the <code>assertion</code> value). The consumer verifies the signature against the provider's JWKS, enforces replay protection, and returns a service-signed identity_assertion bound to the matched user.</p>
   <label>ID-JAG assertion
     <textarea id="assertion" placeholder="eyJhbGc..."></textarea>
   </label>
-  <label>Requested credential type
-    <select id="cred-type">
-      <option value="access_token">access_token</option>
-      <option value="api_key">api_key</option>
-    </select>
-  </label>
   <div class="label">Request</div>
   <div class="req" id="exchange-req"><pre></pre></div>
-  <button class="primary" type="button" data-action="exchange">Exchange</button>
+  <button class="primary" type="button" data-action="exchange">Exchange at /agent/identity</button>
   <div id="exchange-out"></div>
 </section>
 
-<section id="step-14" hidden>
-  <h2><span class="num">14</span>Call <code>/api/resource</code> with the credential</h2>
-  <p>With a valid credential, the agent can now call the protected API. The response echoes back the resolved user and credential metadata.</p>
+<section id="step-15" hidden>
+  <h2><span class="num">15</span>Exchange the assertion at /oauth2/token</h2>
+  <p>The service-signed identity_assertion goes to the OAuth token endpoint with the RFC 7523 JWT-bearer grant; the response is a standard access_token.</p>
+  <div class="label">Request</div>
+  <div class="req" id="token-req"><pre></pre></div>
+  <button class="primary" type="button" data-action="token-exchange">Exchange</button>
+  <div id="token-out"></div>
+</section>
+
+<section id="step-16" hidden>
+  <h2><span class="num">16</span>Call <code>/api/resource</code></h2>
+  <p>With a valid access_token, the agent calls the protected API. The response echoes back the resolved user and credential metadata.</p>
   <div class="label">Request</div>
   <div class="req" id="call-req"><pre></pre></div>
   <button class="primary" type="button" data-action="call">Call /api/resource</button>
   <div id="call-out"></div>
-  <p class="note" style="margin-top:1rem">Revocation is driven from the provider side — see the provider demo's step 7. When the provider POSTs a <code>logout+jwt</code> to this consumer's <code>/agent/auth/revoke</code>, credentials for that <code>(iss, sub, aud)</code> are marked revoked. Re-clicking the call button will start returning 401.</p>
+  <p class="note" style="margin-top:1rem">Revocation has two surfaces. RFC 7009 token revocation at <code>/oauth2/revoke</code> kills one access_token; the agent can re-exchange the identity_assertion to mint a fresh one. The provider can also POST a <code>logout+jwt</code> to <code>/agent/auth/revoke</code>, which invalidates all credentials for the <code>(iss, sub, aud)</code> — see the provider demo's revoke step.</p>
 </section>
 </div>
 </div>
@@ -285,6 +298,19 @@ async function jsonFetch(path, init = {}) {
   return { status: r.status, ok: r.ok, body, headers: pickedHeaders };
 }
 
+async function formFetch(path, body) {
+  const params = new URLSearchParams(body);
+  const r = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const text = await r.text();
+  let parsed;
+  try { parsed = text ? JSON.parse(text) : ""; } catch { parsed = text; }
+  return { status: r.status, ok: r.ok, body: parsed };
+}
+
 function markDone(stepId) {
   document.getElementById(stepId).classList.add("done");
 }
@@ -295,65 +321,78 @@ function reveal(stepId) {
   el.classList.add("active");
 }
 
+function abbrev(s) { return s ? s.slice(0, 24) + "..." : "<value>"; }
+
 function updateExchangePreview() {
   const body = {
     type: "identity_assertion",
     assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
-    assertion: (document.getElementById("assertion").value || "eyJhbGc...").slice(0, 40) + "...",
-    requested_credential_type: document.getElementById("cred-type").value,
+    assertion: abbrev(document.getElementById("assertion").value || "eyJhbGc..."),
   };
   document.querySelector("#exchange-req pre").textContent =
-    "POST /agent/auth\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+    "POST /agent/identity\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+}
+function updateTokenPreview() {
+  const params = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
+    abbrev(state.identity_assertion);
+  document.querySelector("#token-req pre").textContent =
+    "POST /oauth2/token\\nContent-Type: application/x-www-form-urlencoded\\n\\n" + params;
 }
 function updateCallPreview() {
-  const tok = state.credential ? state.credential.slice(0, 16) + "..." : "<credential>";
+  const tok = state.access_token ? state.access_token.slice(0, 16) + "..." : "<access_token>";
   document.querySelector("#call-req pre").textContent =
     "GET /api/resource\\nAuthorization: Bearer " + tok;
 }
+function updateAnonExchangePreview() {
+  const params = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
+    abbrev(state.anon_identity_assertion);
+  document.querySelector("#anon-exchange-req pre").textContent =
+    "POST /oauth2/token\\nContent-Type: application/x-www-form-urlencoded\\n\\n" + params;
+}
 function updateAnonClaimPreview() {
   const body = {
-    claim_token: state.anon_claim_token ? state.anon_claim_token.slice(0, 16) + "..." : "<claim_token>",
+    claim_token: abbrev(state.anon_claim_token),
     email: document.getElementById("anon-claim-email").value,
   };
   document.querySelector("#anon-claim-req pre").textContent =
-    "POST /agent/auth/claim\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+    "POST /agent/identity/claim\\nContent-Type: application/json\\n\\n" + jsonStr(body);
 }
 function updateAnonCompletePreview() {
   const body = {
-    claim_token: state.anon_claim_token ? state.anon_claim_token.slice(0, 16) + "..." : "<claim_token>",
+    claim_token: abbrev(state.anon_claim_token),
     otp: document.getElementById("anon-otp").value || "<otp>",
   };
   document.querySelector("#anon-complete-req pre").textContent =
-    "POST /agent/auth/claim/complete\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+    "POST /agent/identity/claim/complete\\nContent-Type: application/json\\n\\n" + jsonStr(body);
 }
 function updateEmailRegisterPreview() {
   const body = {
     type: "identity_assertion",
     assertion_type: "verified_email",
     assertion: document.getElementById("email-assertion").value,
-    requested_credential_type: "api_key",
   };
   document.querySelector("#email-register-req pre").textContent =
-    "POST /agent/auth\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+    "POST /agent/identity\\nContent-Type: application/json\\n\\n" + jsonStr(body);
 }
 function updateEmailCompletePreview() {
   const body = {
-    claim_token: state.email_claim_token ? state.email_claim_token.slice(0, 16) + "..." : "<claim_token>",
+    claim_token: abbrev(state.email_claim_token),
     otp: document.getElementById("email-otp").value || "<otp>",
   };
   document.querySelector("#email-complete-req pre").textContent =
-    "POST /agent/auth/claim/complete\\nContent-Type: application/json\\n\\n" + jsonStr(body);
+    "POST /agent/identity/claim/complete\\nContent-Type: application/json\\n\\n" + jsonStr(body);
 }
 
 document.getElementById("assertion").addEventListener("input", updateExchangePreview);
-document.getElementById("cred-type").addEventListener("change", updateExchangePreview);
 document.getElementById("anon-claim-email").addEventListener("input", updateAnonClaimPreview);
 document.getElementById("anon-otp").addEventListener("input", updateAnonCompletePreview);
 document.getElementById("email-assertion").addEventListener("input", updateEmailRegisterPreview);
 document.getElementById("email-otp").addEventListener("input", updateEmailCompletePreview);
 
 updateExchangePreview();
+updateTokenPreview();
 updateCallPreview();
+updateAnonExchangePreview();
 updateAnonClaimPreview();
 updateAnonCompletePreview();
 updateEmailRegisterPreview();
@@ -366,6 +405,7 @@ document.body.addEventListener("click", (e) => {
   if (a === "discover-prm") discoverPrm();
   if (a === "discover-as") discoverAs();
   if (a === "anon-register") anonRegister();
+  if (a === "anon-exchange") anonExchange();
   if (a === "anon-call-pre") anonCallPre();
   if (a === "anon-claim") anonClaim();
   if (a === "anon-complete") anonComplete();
@@ -374,6 +414,7 @@ document.body.addEventListener("click", (e) => {
   if (a === "email-complete") emailComplete();
   if (a === "email-call") emailCall();
   if (a === "exchange") exchange();
+  if (a === "token-exchange") tokenExchange();
   if (a === "call") call();
 });
 document.getElementById("reset").addEventListener("click", () => location.reload());
@@ -403,38 +444,49 @@ async function discoverAs() {
   document.getElementById("discover-as-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
   markDone("step-2");
-  // Reveal all three track headers + first steps together so the user sees
-  // the menu of choices.
   document.getElementById("track-a-header").hidden = false;
   document.getElementById("track-b-header").hidden = false;
   document.getElementById("track-c-header").hidden = false;
-  document.getElementById("step-9").hidden = false;
-  document.getElementById("step-13").hidden = false;
+  document.getElementById("step-10").hidden = false;
+  document.getElementById("step-14").hidden = false;
   reveal("step-3");
 }
 
 async function anonRegister() {
-  const r = await jsonFetch("/agent/auth", {
+  const r = await jsonFetch("/agent/identity", {
     method: "POST",
-    body: JSON.stringify({ type: "anonymous", requested_credential_type: "api_key" }),
+    body: JSON.stringify({ type: "anonymous" }),
   });
   document.getElementById("anon-register-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.anon_credential = r.body.credential;
+  state.anon_identity_assertion = r.body.identity_assertion;
   state.anon_claim_token = r.body.claim_token;
   state.anon_registration_id = r.body.registration_id;
+  updateAnonExchangePreview();
   updateAnonClaimPreview();
   updateAnonCompletePreview();
   markDone("step-3");
   reveal("step-4");
 }
 
+async function anonExchange() {
+  const r = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.anon_identity_assertion,
+  });
+  document.getElementById("anon-exchange-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+  if (!r.ok) return;
+  state.anon_access_token = r.body.access_token;
+  markDone("step-4");
+  reveal("step-5");
+}
+
 async function anonCallPre() {
   const r = await jsonFetch("/api/resource", {
-    headers: { authorization: "Bearer " + state.anon_credential },
+    headers: { authorization: "Bearer " + state.anon_access_token },
   });
   document.getElementById("anon-pre-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
-  if (r.ok) { markDone("step-4"); reveal("step-5"); }
+  if (r.ok) { markDone("step-5"); reveal("step-6"); }
 }
 
 async function anonClaim() {
@@ -442,35 +494,45 @@ async function anonClaim() {
     claim_token: state.anon_claim_token,
     email: document.getElementById("anon-claim-email").value,
   };
-  const r = await jsonFetch("/agent/auth/claim", { method: "POST", body: JSON.stringify(body) });
+  const r = await jsonFetch("/agent/identity/claim", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("anon-claim-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
   const mailUrl = "/mail/" + state.anon_registration_id + ".html";
   document.getElementById("anon-mail-link").innerHTML =
     '<div class="note"><a href="' + escapeHtml(mailUrl) + '" target="_blank">Open the simulated email</a> ' +
     '— click the link inside, read the 6-digit OTP, then come back and paste it below.</div>';
-  markDone("step-5");
-  reveal("step-6");
-  document.getElementById("step-7").hidden = false;
+  markDone("step-6");
+  reveal("step-7");
+  document.getElementById("step-8").hidden = false;
 }
 
 async function anonComplete() {
   const otp = document.getElementById("anon-otp").value.trim();
   const body = { claim_token: state.anon_claim_token, otp };
-  const r = await jsonFetch("/agent/auth/claim/complete", { method: "POST", body: JSON.stringify(body) });
+  const r = await jsonFetch("/agent/identity/claim/complete", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("anon-complete-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  markDone("step-6");
   markDone("step-7");
-  reveal("step-8");
+  markDone("step-8");
+  reveal("step-9");
 }
 
 async function anonCallPost() {
+  /* Re-exchange the same identity_assertion to pick up post-claim scope. */
+  const exch = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.anon_identity_assertion,
+  });
+  if (!exch.ok) {
+    document.getElementById("anon-post-out").innerHTML = resBlock(exch.status, null, exch.body, false);
+    return;
+  }
+  state.anon_access_token = exch.body.access_token;
   const r = await jsonFetch("/api/resource", {
-    headers: { authorization: "Bearer " + state.anon_credential },
+    headers: { authorization: "Bearer " + state.anon_access_token },
   });
   document.getElementById("anon-post-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
-  if (r.ok) markDone("step-8");
+  if (r.ok) markDone("step-9");
 }
 
 async function emailRegister() {
@@ -479,9 +541,8 @@ async function emailRegister() {
     type: "identity_assertion",
     assertion_type: "verified_email",
     assertion: email,
-    requested_credential_type: "api_key",
   };
-  const r = await jsonFetch("/agent/auth", { method: "POST", body: JSON.stringify(body) });
+  const r = await jsonFetch("/agent/identity", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("email-register-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
   state.email_claim_token = r.body.claim_token;
@@ -491,29 +552,38 @@ async function emailRegister() {
   document.getElementById("email-mail-link").innerHTML =
     '<div class="note"><a href="' + escapeHtml(mailUrl) + '" target="_blank">Open the simulated email</a> ' +
     '— click the link, read the 6-digit OTP, then come back and paste it below.</div>';
-  markDone("step-9");
-  reveal("step-10");
-  document.getElementById("step-11").hidden = false;
+  markDone("step-10");
+  reveal("step-11");
+  document.getElementById("step-12").hidden = false;
 }
 
 async function emailComplete() {
   const otp = document.getElementById("email-otp").value.trim();
   const body = { claim_token: state.email_claim_token, otp };
-  const r = await jsonFetch("/agent/auth/claim/complete", { method: "POST", body: JSON.stringify(body) });
+  const r = await jsonFetch("/agent/identity/claim/complete", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("email-complete-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.email_credential = r.body.credential;
-  markDone("step-10");
+  state.email_identity_assertion = r.body.identity_assertion;
   markDone("step-11");
-  reveal("step-12");
+  markDone("step-12");
+  reveal("step-13");
 }
 
 async function emailCall() {
+  const exch = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.email_identity_assertion,
+  });
+  if (!exch.ok) {
+    document.getElementById("email-call-out").innerHTML = resBlock(exch.status, null, exch.body, false);
+    return;
+  }
+  state.email_access_token = exch.body.access_token;
   const r = await jsonFetch("/api/resource", {
-    headers: { authorization: "Bearer " + state.email_credential },
+    headers: { authorization: "Bearer " + state.email_access_token },
   });
   document.getElementById("email-call-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
-  if (r.ok) markDone("step-12");
+  if (r.ok) markDone("step-13");
 }
 
 async function exchange() {
@@ -527,23 +597,35 @@ async function exchange() {
     type: "identity_assertion",
     assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
     assertion,
-    requested_credential_type: document.getElementById("cred-type").value,
   };
-  const r = await jsonFetch("/agent/auth", { method: "POST", body: JSON.stringify(body) });
+  const r = await jsonFetch("/agent/identity", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("exchange-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.credential = r.body.credential;
+  state.identity_assertion = r.body.identity_assertion;
+  updateTokenPreview();
+  markDone("step-14");
+  reveal("step-15");
+}
+
+async function tokenExchange() {
+  const r = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.identity_assertion,
+  });
+  document.getElementById("token-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+  if (!r.ok) return;
+  state.access_token = r.body.access_token;
   updateCallPreview();
-  markDone("step-13");
-  reveal("step-14");
+  markDone("step-15");
+  reveal("step-16");
 }
 
 async function call() {
   const r = await jsonFetch("/api/resource", {
-    headers: { authorization: "Bearer " + state.credential },
+    headers: { authorization: "Bearer " + state.access_token },
   });
   document.getElementById("call-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
-  if (r.ok) markDone("step-14");
+  if (r.ok) markDone("step-16");
 }
 </script>
 </body></html>`;

--- a/agent-services/src/routes/token.ts
+++ b/agent-services/src/routes/token.ts
@@ -106,13 +106,17 @@ tokenRouter.post(config.tokenEndpointPath, formParser, async (req, res) => {
   }
 
   /*
-   * Anonymous unclaimed registrations get pre-claim scopes; everything else
-   * gets the full scope set. Email-verification registrations always reach
-   * /oauth2/token via a post-claim identity_assertion (the registration has
-   * a user bound), so the same rule applies.
+   * Anonymous registrations stay on pre-claim scopes until a human has
+   * actually confirmed ownership (status: claimed). `unclaimed` and
+   * `pending_claim` both predate confirmation — the latter means the
+   * agent has kicked off a claim ceremony but the user hasn't yet
+   * approved it, so the pre-claim cap still applies. Email-verification
+   * registrations always reach /oauth2/token via a post-claim
+   * identity_assertion (the registration is bound to a user before the
+   * assertion is minted), so they get the full set.
    */
   const scope =
-    registration.kind === "anonymous" && registration.status === "unclaimed"
+    registration.kind === "anonymous" && registration.status !== "claimed"
       ? config.preClaimScopes
       : config.scopesSupported;
 

--- a/agent-services/src/routes/token.ts
+++ b/agent-services/src/routes/token.ts
@@ -1,0 +1,172 @@
+import express, { Router } from "express";
+import { config } from "../config.js";
+import {
+  parseBody,
+  revocationEndpointBody,
+  tokenEndpointBody,
+} from "../schemas.js";
+import {
+  findRegistrationById,
+  issueAccessToken,
+  revokeCredential,
+} from "../store.js";
+import { verifyServiceIdJag } from "../verify.js";
+
+/*
+ * OAuth credential surface for the agent-auth profile.
+ *
+ * /oauth2/token (RFC 7523 JWT-bearer) — exchanges a service-signed
+ * identity_assertion for an access_token. The assertion's `sub` resolves to
+ * a registration; the scope set is derived from the registration's state
+ * (pre-claim scopes for an unclaimed anonymous registration, full scopes
+ * once claimed or for any identity-bound registration).
+ *
+ * /oauth2/revoke (RFC 7009) — kills a single access_token by value. 200 on
+ * success, idempotent, no enumeration leakage on unknown tokens.
+ */
+
+export const tokenRouter = Router();
+
+const formParser = express.urlencoded({ extended: false });
+
+type OAuthErrorCode =
+  | "invalid_request"
+  | "invalid_client"
+  | "invalid_grant"
+  | "unauthorized_client"
+  | "unsupported_grant_type"
+  | "invalid_scope";
+
+/**
+ * Per RFC 6749 §5.1, the AS MUST set Cache-Control: no-store and Pragma:
+ * no-cache on responses containing tokens or other sensitive data. Apply to
+ * every response from the token endpoint, success and error alike.
+ */
+function setOAuthHeaders(res: express.Response): void {
+  res.set("Cache-Control", "no-store");
+  res.set("Pragma", "no-cache");
+}
+
+/**
+ * RFC 6749 §5.2 error envelope. Status is 400 by default; invalid_client
+ * MAY be 401 (and SHOULD be 401 if the client tried to authenticate via the
+ * Authorization header — not relevant for this profile, which is bearer-
+ * assertion only).
+ */
+function oauthError(
+  res: express.Response,
+  code: OAuthErrorCode,
+  description: string,
+): void {
+  const status = code === "invalid_client" ? 401 : 400;
+  setOAuthHeaders(res);
+  res.status(status).json({ error: code, error_description: description });
+}
+
+tokenRouter.post(config.tokenEndpointPath, formParser, async (req, res) => {
+  /*
+   * RFC 6749 §5.2 names a dedicated error code for grant_type problems.
+   * Check it before the rest of the body so we don't collapse the wrong-
+   * grant case into invalid_request.
+   */
+  const grantType =
+    typeof req.body?.grant_type === "string" ? req.body.grant_type : undefined;
+  if (grantType !== "urn:ietf:params:oauth:grant-type:jwt-bearer") {
+    return oauthError(
+      res,
+      "unsupported_grant_type",
+      grantType
+        ? `Unsupported grant_type: ${grantType}.`
+        : "Missing grant_type.",
+    );
+  }
+
+  const parsed = parseBody(tokenEndpointBody, req.body);
+  if (!parsed.ok) return oauthError(res, "invalid_request", parsed.message);
+
+  const verified = await verifyServiceIdJag(parsed.value.assertion);
+  if (!verified.ok) {
+    return oauthError(res, "invalid_grant", verified.error.message);
+  }
+
+  const registration = findRegistrationById(verified.claims.sub);
+  if (!registration) {
+    return oauthError(
+      res,
+      "invalid_grant",
+      `No registration found for sub=${verified.claims.sub}.`,
+    );
+  }
+  if (registration.status === "expired") {
+    return oauthError(
+      res,
+      "invalid_grant",
+      `The registration has expired. Re-register at ${config.identityEndpointPath}.`,
+    );
+  }
+
+  /*
+   * Anonymous unclaimed registrations get pre-claim scopes; everything else
+   * gets the full scope set. Email-verification registrations always reach
+   * /oauth2/token via a post-claim identity_assertion (the registration has
+   * a user bound), so the same rule applies.
+   */
+  const scope =
+    registration.kind === "anonymous" && registration.status === "unclaimed"
+      ? config.preClaimScopes
+      : config.scopesSupported;
+
+  const credential = issueAccessToken({
+    userId: registration.user_id,
+    scope,
+    source: sourceForRegistrationKind(registration.kind),
+    iss: registration.id_jag?.iss,
+    sub: registration.id_jag?.sub,
+    aud: registration.id_jag?.aud,
+    registrationId: registration.id,
+  });
+
+  console.log(
+    `[token] issued access_token for registration=${registration.id} status=${registration.status} scopes=${scope.join(",")}`,
+  );
+
+  const expiresIn = credential.expires_at
+    ? Math.max(
+        0,
+        Math.floor((credential.expires_at.getTime() - Date.now()) / 1000),
+      )
+    : config.accessTokenTtlSeconds;
+
+  setOAuthHeaders(res);
+  res.json({
+    access_token: credential.token,
+    token_type: "Bearer",
+    expires_in: expiresIn,
+    scope: scope.join(" "),
+  });
+});
+
+tokenRouter.post(config.revocationEndpointPath, formParser, (req, res) => {
+  const parsed = parseBody(revocationEndpointBody, req.body);
+  if (!parsed.ok) {
+    return oauthError(res, "invalid_request", parsed.message);
+  }
+  /*
+   * RFC 7009 §2.2: unknown / already-revoked tokens return 200 to prevent
+   * enumeration. We only error on a malformed body (missing token field),
+   * which is an integration bug, not a probe.
+   */
+  const revoked = revokeCredential(parsed.value.token);
+  console.log(
+    `[token] revocation ${revoked ? "applied" : "no-op"} for token=${parsed.value.token.slice(0, 8)}...`,
+  );
+  setOAuthHeaders(res);
+  res.status(200).end();
+});
+
+function sourceForRegistrationKind(
+  kind: "anonymous" | "email_verification" | "id_jag",
+): "anonymous" | "email_verification" | "identity_assertion" {
+  if (kind === "id_jag") return "identity_assertion";
+  return kind;
+}

--- a/agent-services/src/routes/well-known.ts
+++ b/agent-services/src/routes/well-known.ts
@@ -22,21 +22,23 @@ wellKnownRouter.get("/.well-known/oauth-authorization-server", (_req, res) => {
     authorization_servers: [config.baseUrl],
     scopes_supported: config.scopesSupported,
     bearer_methods_supported: ["header"],
+
+    issuer: config.baseUrl,
+    token_endpoint: `${config.baseUrl}${config.tokenEndpointPath}`,
+    revocation_endpoint: `${config.baseUrl}${config.revocationEndpointPath}`,
+    grant_types_supported: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+
     agent_auth: {
       skill: `${config.baseUrl}/auth.md`,
-      register_uri: `${config.baseUrl}/agent/auth`,
-      claim_uri: `${config.baseUrl}/agent/auth/claim`,
-      revocation_uri: `${config.baseUrl}/agent/auth/revoke`,
+      identity_endpoint: `${config.baseUrl}${config.identityEndpointPath}`,
+      claim_endpoint: `${config.baseUrl}${config.claimEndpointPath}`,
+      revocation_uri: `${config.baseUrl}${config.revocationUriPath}`,
       identity_types_supported: ["anonymous", "identity_assertion"],
-      anonymous: {
-        credential_types_supported: ["api_key"],
-      },
       identity_assertion: {
         assertion_types_supported: [
           "urn:ietf:params:oauth:token-type:id-jag",
           "verified_email",
         ],
-        credential_types_supported: ["access_token", "api_key"],
       },
       events_supported: [
         "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked",

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -7,19 +7,16 @@ const idJagAssertionBody = z.object({
   type: z.literal("identity_assertion"),
   assertion_type: z.literal(ID_JAG),
   assertion: z.string().min(1),
-  requested_credential_type: z.enum(["access_token", "api_key"]),
 });
 
 const emailAssertionBody = z.object({
   type: z.literal("identity_assertion"),
   assertion_type: z.literal(EMAIL_ASSERTION),
   assertion: z.email(),
-  requested_credential_type: z.enum(["access_token", "api_key"]),
 });
 
 const anonymousBody = z.object({
   type: z.literal("anonymous"),
-  requested_credential_type: z.literal("api_key"),
 });
 
 export const agentAuthBody = z.union([
@@ -40,6 +37,23 @@ export const claimCompleteBody = z.object({
 
 export const generateOtpBody = z.object({
   claim_attempt_token: z.string().min(1),
+});
+
+/**
+ * RFC 7523 JWT-bearer grant. The agent presents a service-signed
+ * identity_assertion as the `assertion` parameter; the service exchanges it
+ * for an access_token scoped per the registration's state.
+ */
+export const tokenEndpointBody = z.object({
+  grant_type: z.literal("urn:ietf:params:oauth:grant-type:jwt-bearer"),
+  assertion: z.string().min(1),
+  resource: z.string().url().optional(),
+});
+
+/** RFC 7009 token revocation. */
+export const revocationEndpointBody = z.object({
+  token: z.string().min(1),
+  token_type_hint: z.literal("access_token").optional(),
 });
 
 export const ASSERTION_TYPES = { ID_JAG, EMAIL_ASSERTION } as const;

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -10,11 +10,8 @@ export type User = {
   name?: string;
 };
 
-export type CredentialType = "access_token" | "api_key";
-
 export type Credential = {
   token: string;
-  type: CredentialType;
   user_id?: string;
   scope: string[];
   issued_at: Date;
@@ -35,41 +32,87 @@ export type Delegation = {
   last_seen: Date;
 };
 
-export type RegistrationKind = "anonymous" | "email_verification";
+export type RegistrationKind = "anonymous" | "email_verification" | "id_jag";
 
-export type Registration = {
+/**
+ * The user-facing leg of the claim ceremony. Tracks the OTP-view link sent
+ * to the user and (once /attempt/challenge fires) the OTP that link reveals.
+ */
+export type RegistrationClaimAttempt = {
+  id: string;
+  view_token_hash: string;
+  view_expires_at: Date;
+  otp?: {
+    hash: string;
+    generated_at: Date;
+    expires_at: Date;
+  };
+};
+
+/**
+ * The agent-facing leg of the claim ceremony. The agent holds the claim
+ * token; the email recipient holds the view token (inside the attempt). For
+ * anonymous registrations the email/attempt aren't populated until the agent
+ * initiates claim via /agent/identity/claim.
+ */
+export type RegistrationClaim = {
+  token_hash: string;
+  email?: string;
+  expires_at: Date;
+  attempt?: RegistrationClaimAttempt;
+};
+
+/**
+ * The (iss, sub, aud) of the original provider ID-JAG. Present on id_jag
+ * registrations so that future credential lifecycle (revocation, audit,
+ * /token refresh) has a durable identity to anchor to.
+ */
+export type RegistrationIdJag = {
+  iss: string;
+  sub: string;
+  aud: string;
+};
+
+export class Registration {
   id: string;
   kind: RegistrationKind;
   user_id?: string;
-  // Anonymous registrations get a credential at registration time. Email-
-  // verification registrations get one only on /complete.
-  credential_token?: string;
-  // The credential type the agent asked for at registration time. Persisted
-  // for email_verification so /complete can mint the right type.
-  requested_credential_type: CredentialType;
-  // Hash of the agent-side claim_token returned at /agent-auth.
-  claim_token_hash: string;
-  // The user-facing ceremony email is keyed by the claim_view_token. For
-  // anonymous, it's set at /agent-auth/claim. For email_verification, it's
-  // set at /agent-auth itself.
-  claim_view_token_hash?: string;
-  claim_view_expires_at?: Date;
-  // For email_verification, captured at /agent-auth. For anonymous, captured
-  // at /agent-auth/claim.
-  claim_email?: string;
-  // Identifies the current (or last) claim attempt. Rotates each time a fresh
-  // attempt is initiated — including same-email retries after a prior
-  // attempt expired.
-  claim_attempt_id?: string;
-  // Stamped when /generate-otp first mints an OTP for this registration.
-  otp_hash?: string;
-  otp_expires_at?: Date;
-  otp_generated_at?: Date;
-  status: "unclaimed" | "pending_claim" | "claimed" | "expired";
   created_at: Date;
-  expires_at: Date;
   claimed_at?: Date;
-};
+  claim?: RegistrationClaim;
+  id_jag?: RegistrationIdJag;
+
+  constructor(init: {
+    id: string;
+    kind: RegistrationKind;
+    created_at: Date;
+    user_id?: string;
+    claimed_at?: Date;
+    claim?: RegistrationClaim;
+    id_jag?: RegistrationIdJag;
+  }) {
+    this.id = init.id;
+    this.kind = init.kind;
+    this.user_id = init.user_id;
+    this.created_at = init.created_at;
+    this.claimed_at = init.claimed_at;
+    this.claim = init.claim;
+    this.id_jag = init.id_jag;
+  }
+
+  /**
+   * Derived from the registration's other fields — no separate `status`
+   * column to keep in sync, no sweeper job needed to mark things expired.
+   */
+  get status(): "unclaimed" | "pending_claim" | "claimed" | "expired" {
+    if (this.claimed_at) return "claimed";
+    if (this.claim && this.claim.expires_at.getTime() < Date.now()) {
+      return "expired";
+    }
+    if (this.claim?.attempt) return "pending_claim";
+    return "unclaimed";
+  }
+}
 
 export const users = new Map<string, User>();
 export const credentials = new Map<string, Credential>();
@@ -153,9 +196,10 @@ function randomToken(prefix: string, bytes = 24): string {
 }
 
 export function issueAccessToken(input: {
-  userId: string;
+  /** Optional: anonymous registrations (pre-claim) have no bound user yet. */
+  userId?: string;
   scope: string[];
-  source: "identity_assertion" | "email_verification";
+  source: "identity_assertion" | "email_verification" | "anonymous";
   iss?: string;
   sub?: string;
   aud?: string;
@@ -165,7 +209,6 @@ export function issueAccessToken(input: {
   const token = randomToken("at_");
   const cred: Credential = {
     token,
-    type: "access_token",
     user_id: input.userId,
     scope: input.scope,
     issued_at: now,
@@ -177,59 +220,6 @@ export function issueAccessToken(input: {
     aud: input.aud,
     registration_id: input.registrationId,
   };
-  credentials.set(token, cred);
-  return cred;
-}
-
-export type IssueApiKeyInput =
-  | {
-      source: "anonymous";
-      scope: string[];
-      registrationId: string;
-    }
-  | {
-      source: "email_verification";
-      scope: string[];
-      userId: string;
-      registrationId: string;
-    }
-  | {
-      source: "identity_assertion";
-      scope: string[];
-      userId: string;
-      iss: string;
-      sub: string;
-      aud: string;
-    };
-
-export function issueApiKey(input: IssueApiKeyInput): Credential {
-  const token = randomToken("sk_test_", 20);
-  const base = {
-    token,
-    type: "api_key" as const,
-    scope: input.scope,
-    issued_at: new Date(),
-    revoked: false,
-    source: input.source,
-  };
-  let cred: Credential;
-  if (input.source === "anonymous") {
-    cred = { ...base, registration_id: input.registrationId };
-  } else if (input.source === "email_verification") {
-    cred = {
-      ...base,
-      user_id: input.userId,
-      registration_id: input.registrationId,
-    };
-  } else {
-    cred = {
-      ...base,
-      user_id: input.userId,
-      iss: input.iss,
-      sub: input.sub,
-      aud: input.aud,
-    };
-  }
   credentials.set(token, cred);
   return cred;
 }
@@ -257,6 +247,13 @@ export function revokeForDelegation(
   return count;
 }
 
+export function revokeCredential(token: string): boolean {
+  const c = credentials.get(token);
+  if (!c || c.revoked) return false;
+  c.revoked = true;
+  return true;
+}
+
 export function recordJti(jti: string, expSeconds: number): "ok" | "replay" {
   sweepJtis();
   if (seenJtis.has(jti)) return "replay";
@@ -275,93 +272,115 @@ export function sha256Hex(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
-export function createAnonymousRegistration(input: {
-  requestedCredentialType: CredentialType;
-}): {
+/**
+ * Anonymous registrations start with an empty claim (only the agent's claim
+ * token is set — no email, no attempt). The agent receives the claim token
+ * in the registration response and can later initiate the user-facing
+ * ceremony by calling /agent/identity/claim with an email address.
+ */
+export function createAnonymousRegistration(): {
   registration: Registration;
-  credential: Credential;
   claimTokenPlaintext: string;
 } {
   const now = new Date();
   const registrationId = `reg_${randomBytes(16).toString("base64url")}`;
-
-  // No user is created up front — an unclaimed agent has a credential but
-  // no bound identity. The registration is linked to a user on claim.
-  const credential =
-    input.requestedCredentialType === "api_key"
-      ? issueApiKey({
-          scope: config.preClaimScopes,
-          source: "anonymous",
-          registrationId,
-        })
-      : (() => {
-          // Spec: anonymous only supports api_key. Caller should have
-          // rejected before reaching here.
-          throw new Error(
-            "anonymous registration only supports api_key credentials",
-          );
-        })();
-
   const claimTokenPlaintext = `clm_${randomBytes(19).toString("base64url")}`;
 
-  const registration: Registration = {
+  const registration = new Registration({
     id: registrationId,
     kind: "anonymous",
-    credential_token: credential.token,
-    requested_credential_type: input.requestedCredentialType,
-    claim_token_hash: sha256Hex(claimTokenPlaintext),
-    status: "unclaimed",
     created_at: now,
-    expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
-  };
-
+    claim: {
+      token_hash: sha256Hex(claimTokenPlaintext),
+      expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
+    },
+  });
   registrations.set(registration.id, registration);
-
-  return { registration, credential, claimTokenPlaintext };
+  return { registration, claimTokenPlaintext };
 }
 
-export function createEmailVerificationRegistration(input: {
-  email: string;
-  requestedCredentialType: CredentialType;
-}): {
+/**
+ * Email-verification registrations bundle the claim attempt: we send the
+ * email immediately and the agent polls /agent/identity/claim/complete with
+ * the OTP the user reads back. No separate /claim initiation needed.
+ */
+export function createEmailVerificationRegistration(input: { email: string }): {
   registration: Registration;
   claimTokenPlaintext: string;
   claimViewTokenPlaintext: string;
 } {
   const now = new Date();
   const registrationId = `reg_${randomBytes(16).toString("base64url")}`;
-
   const claimTokenPlaintext = `clm_${randomBytes(19).toString("base64url")}`;
   const claimViewTokenPlaintext = `cvt_${randomBytes(24).toString("base64url")}`;
 
-  // Email-verification registrations bundle the claim attempt: the email
-  // ceremony starts here, so the agent can poll /complete directly.
-  const registration: Registration = {
+  const registration = new Registration({
     id: registrationId,
     kind: "email_verification",
-    requested_credential_type: input.requestedCredentialType,
-    claim_token_hash: sha256Hex(claimTokenPlaintext),
-    claim_view_token_hash: sha256Hex(claimViewTokenPlaintext),
-    claim_view_expires_at: new Date(
-      now.getTime() + config.claimViewTokenTtlSeconds * 1000,
-    ),
-    claim_email: input.email,
-    claim_attempt_id: `cla_${randomBytes(16).toString("base64url")}`,
-    status: "pending_claim",
     created_at: now,
-    expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
-  };
-
+    claim: {
+      token_hash: sha256Hex(claimTokenPlaintext),
+      email: input.email,
+      expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
+      attempt: {
+        id: `cla_${randomBytes(16).toString("base64url")}`,
+        view_token_hash: sha256Hex(claimViewTokenPlaintext),
+        view_expires_at: new Date(
+          now.getTime() + config.claimViewTokenTtlSeconds * 1000,
+        ),
+      },
+    },
+  });
   registrations.set(registration.id, registration);
-
   return { registration, claimTokenPlaintext, claimViewTokenPlaintext };
+}
+
+function idJagRegistrationKey(iss: string, sub: string, aud: string): string {
+  return `reg_${sha256Hex(`${iss}|${sub}|${aud}`).slice(0, 22)}`;
+}
+
+/**
+ * ID-JAG clean match: the matcher found an existing delegation or JIT-
+ * provisioned a fresh user. No claim ceremony required. Returns an existing
+ * registration for the same (iss, sub, aud) if one is already on file —
+ * keeps the registration_id stable across repeated ID-JAG presentations
+ * from the same provider/user pair.
+ */
+export function findOrCreateIdJagRegistration(input: {
+  iss: string;
+  sub: string;
+  aud: string;
+  userId: string;
+}): Registration {
+  const id = idJagRegistrationKey(input.iss, input.sub, input.aud);
+  const existing = registrations.get(id);
+  if (existing) {
+    /* Keep the user binding current in case of JIT-provision races. */
+    existing.user_id = input.userId;
+    return existing;
+  }
+  const now = new Date();
+  const registration = new Registration({
+    id,
+    kind: "id_jag",
+    user_id: input.userId,
+    created_at: now,
+    claimed_at: now,
+    id_jag: { iss: input.iss, sub: input.sub, aud: input.aud },
+  });
+  registrations.set(registration.id, registration);
+  return registration;
+}
+
+export function findRegistrationById(id: string): Registration | undefined {
+  return registrations.get(id);
 }
 
 export function findRegistrationByClaimHash(
   hash: string,
 ): Registration | undefined {
   for (const r of registrations.values()) {
-    if (r.claim_token_hash === hash) return r;
+    if (r.claim?.token_hash === hash) return r;
   }
   return undefined;
 }
@@ -370,7 +389,7 @@ export function findRegistrationByClaimViewHash(
   hash: string,
 ): Registration | undefined {
   for (const r of registrations.values()) {
-    if (r.claim_view_token_hash === hash) return r;
+    if (r.claim?.attempt?.view_token_hash === hash) return r;
   }
   return undefined;
 }
@@ -381,34 +400,45 @@ export function recordAnonymousClaimAttempt(
 ): string {
   const now = new Date();
   const plaintext = `cvt_${randomBytes(24).toString("base64url")}`;
-  registration.status = "pending_claim";
-  registration.claim_email = email;
-  registration.claim_attempt_id = `cla_${randomBytes(16).toString("base64url")}`;
-  registration.claim_view_token_hash = sha256Hex(plaintext);
-  registration.claim_view_expires_at = new Date(
-    now.getTime() + config.claimViewTokenTtlSeconds * 1000,
-  );
+  if (!registration.claim) {
+    throw new Error("registration has no claim handle");
+  }
+  registration.claim.email = email;
+  registration.claim.attempt = {
+    id: `cla_${randomBytes(16).toString("base64url")}`,
+    view_token_hash: sha256Hex(plaintext),
+    view_expires_at: new Date(
+      now.getTime() + config.claimViewTokenTtlSeconds * 1000,
+    ),
+  };
   return plaintext;
 }
 
-// Mints a fresh OTP and overwrites any prior one. Refreshing the claim-view
-// page reissues a code; the previous code is no longer accepted.
+/**
+ * Mints a fresh OTP and overwrites any prior one. Refreshing the claim-view
+ * page reissues a code; the previous code is no longer accepted.
+ */
 export function generateOtpForRegistration(registration: Registration): {
   otp: string;
   expiresAt: Date;
 } {
+  const attempt = registration.claim?.attempt;
+  if (!attempt) {
+    throw new Error("registration has no active claim attempt");
+  }
   const now = new Date();
   const otp = String(randomInt(0, 1_000_000)).padStart(6, "0");
-  registration.otp_hash = sha256Hex(otp);
-  registration.otp_generated_at = now;
-  registration.otp_expires_at = new Date(
-    now.getTime() + config.otpTtlSeconds * 1000,
-  );
-  return { otp, expiresAt: registration.otp_expires_at };
+  const expiresAt = new Date(now.getTime() + config.otpTtlSeconds * 1000);
+  attempt.otp = {
+    hash: sha256Hex(otp),
+    generated_at: now,
+    expires_at: expiresAt,
+  };
+  return { otp, expiresAt };
 }
 
 export type CompleteClaimResult =
-  | { ok: true; registration: Registration; credential?: Credential }
+  | { ok: true; registration: Registration; user: User }
   | {
       ok: false;
       error:
@@ -426,82 +456,43 @@ export function completeClaim(
   if (registration.status === "claimed") {
     return { ok: false, error: "previously_claimed" };
   }
-  if (registration.expires_at.getTime() < Date.now()) {
+  if (registration.status === "expired") {
     return { ok: false, error: "claim_expired" };
   }
-  if (!registration.otp_hash || !registration.otp_expires_at) {
+  const attempt = registration.claim?.attempt;
+  if (!attempt?.otp) {
     return { ok: false, error: "otp_not_generated" };
   }
-  if (registration.otp_expires_at.getTime() < Date.now()) {
+  if (attempt.otp.expires_at.getTime() < Date.now()) {
     return { ok: false, error: "otp_expired" };
   }
-  if (sha256Hex(otp) !== registration.otp_hash) {
+  if (sha256Hex(otp) !== attempt.otp.hash) {
     return { ok: false, error: "otp_invalid" };
   }
 
+  const email = registration.claim!.email!;
+  let user = findUserByEmail(email);
+  if (!user) {
+    user = createUser({ email, email_verified: true });
+  }
+  registration.user_id = user.id;
+  registration.claimed_at = new Date();
+  /* Clear claim handle: same registration can't be re-claimed. */
+  registration.claim = undefined;
+
   if (registration.kind === "anonymous") {
-    return completeAnonymousClaim(registration);
+    /*
+     * In-place scope upgrade: any access_tokens issued from this
+     * registration's pre-claim assertion remain valid; their scope set is
+     * widened to post_claim. The agent keeps using the same token.
+     */
+    for (const cred of credentials.values()) {
+      if (cred.registration_id === registration.id && !cred.revoked) {
+        cred.user_id = user.id;
+        cred.scope = config.postClaimScopes;
+      }
+    }
   }
-  return completeEmailVerificationClaim(registration);
-}
 
-function completeAnonymousClaim(
-  registration: Registration,
-): CompleteClaimResult {
-  const email = registration.claim_email!;
-  let user = findUserByEmail(email);
-  if (!user) {
-    user = createUser({ email, email_verified: true });
-  }
-  registration.status = "claimed";
-  registration.user_id = user.id;
-  registration.claimed_at = new Date();
-  registration.otp_hash = undefined;
-  registration.otp_expires_at = undefined;
-  registration.claim_view_token_hash = undefined;
-  registration.claim_view_expires_at = undefined;
-  // In-place scope upgrade on the existing API key.
-  const cred = registration.credential_token
-    ? credentials.get(registration.credential_token)
-    : undefined;
-  if (cred) {
-    cred.user_id = user.id;
-    cred.scope = config.postClaimScopes;
-  }
-  return { ok: true, registration, credential: cred };
-}
-
-function completeEmailVerificationClaim(
-  registration: Registration,
-): CompleteClaimResult {
-  const email = registration.claim_email!;
-  let user = findUserByEmail(email);
-  if (!user) {
-    user = createUser({ email, email_verified: true });
-  }
-  registration.status = "claimed";
-  registration.user_id = user.id;
-  registration.claimed_at = new Date();
-  registration.otp_hash = undefined;
-  registration.otp_expires_at = undefined;
-  registration.claim_view_token_hash = undefined;
-  registration.claim_view_expires_at = undefined;
-
-  const scope = config.postClaimScopes;
-  const credential =
-    registration.requested_credential_type === "api_key"
-      ? issueApiKey({
-          source: "email_verification",
-          scope,
-          userId: user.id,
-          registrationId: registration.id,
-        })
-      : issueAccessToken({
-          source: "email_verification",
-          scope,
-          userId: user.id,
-          registrationId: registration.id,
-        });
-  registration.credential_token = credential.token;
-  return { ok: true, registration, credential };
+  return { ok: true, registration, user };
 }

--- a/agent-services/src/verify.ts
+++ b/agent-services/src/verify.ts
@@ -1,6 +1,6 @@
 import { type JWTPayload, decodeProtectedHeader, jwtVerify } from "jose";
 import { config } from "./config.js";
-import { getPrivateKey, signServiceJwt } from "./keys.js";
+import { getPublicKey, signServiceJwt } from "./keys.js";
 import { type Registration, recordJti } from "./store.js";
 import { getJwks, isTrustedIssuer } from "./trust.js";
 import { randomUUID } from "node:crypto";
@@ -262,8 +262,8 @@ export async function verifyServiceIdJag(
     };
   }
   try {
-    const privateKey = await getPrivateKey();
-    const res = await jwtVerify(jwt, privateKey, {
+    const publicKey = await getPublicKey();
+    const res = await jwtVerify(jwt, publicKey, {
       issuer: config.baseUrl,
       audience: config.baseUrl,
       typ: "oauth-id-jag+jwt",

--- a/agent-services/src/verify.ts
+++ b/agent-services/src/verify.ts
@@ -1,7 +1,9 @@
 import { type JWTPayload, decodeProtectedHeader, jwtVerify } from "jose";
 import { config } from "./config.js";
-import { recordJti } from "./store.js";
+import { getPrivateKey, signServiceJwt } from "./keys.js";
+import { type Registration, recordJti } from "./store.js";
 import { getJwks, isTrustedIssuer } from "./trust.js";
+import { randomUUID } from "node:crypto";
 
 export type VerifyError = {
   code:
@@ -191,6 +193,101 @@ export async function verifyLogoutJwt(
     return { ok: true, claims };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: { code: "invalid_signature", message } };
+  }
+}
+
+export type ServiceAssertionClaims = JWTPayload & {
+  iss: string;
+  sub: string;
+  aud: string;
+  jti: string;
+  email?: string;
+  email_verified?: boolean;
+  amr?: string[];
+};
+
+/**
+ * Mint a service-signed identity_assertion bound to a registration. The
+ * agent presents this at /oauth2/token (RFC 7523 JWT-bearer) to obtain an
+ * access_token. `sub` is the registration id so the token endpoint can
+ * resolve back to the registration's state on exchange.
+ */
+export async function signServiceIdJag(input: {
+  registration: Registration;
+  email?: string;
+  emailVerified?: boolean;
+  amr?: string[];
+}): Promise<{ jwt: string; expiresAt: Date }> {
+  const payload: Record<string, unknown> = {
+    iss: config.baseUrl,
+    sub: input.registration.id,
+    aud: config.baseUrl,
+    jti: `jti_${randomUUID()}`,
+  };
+  if (input.email) payload.email = input.email;
+  if (input.emailVerified !== undefined) {
+    payload.email_verified = input.emailVerified;
+  }
+  if (input.amr) payload.amr = input.amr;
+  return signServiceJwt(
+    payload,
+    "oauth-id-jag+jwt",
+    config.serviceAssertionTtlSeconds,
+  );
+}
+
+export async function verifyServiceIdJag(
+  jwt: string,
+): Promise<
+  | { ok: true; claims: ServiceAssertionClaims }
+  | { ok: false; error: VerifyError }
+> {
+  let header;
+  try {
+    header = decodeProtectedHeader(jwt);
+  } catch {
+    return {
+      ok: false,
+      error: { code: "invalid_request", message: "Malformed JWT header." },
+    };
+  }
+  if (header.typ && header.typ !== "oauth-id-jag+jwt") {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_request",
+        message: `Unexpected typ ${String(header.typ)}; wanted oauth-id-jag+jwt.`,
+      },
+    };
+  }
+  try {
+    const privateKey = await getPrivateKey();
+    const res = await jwtVerify(jwt, privateKey, {
+      issuer: config.baseUrl,
+      audience: config.baseUrl,
+      typ: "oauth-id-jag+jwt",
+      clockTolerance: config.clockSkewSeconds,
+    });
+    const claims = res.payload as ServiceAssertionClaims;
+    if (!claims.jti || !claims.sub) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_request",
+          message: "Missing required claim (jti or sub).",
+        },
+      };
+    }
+    return { ok: true, claims };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/expired|exp/i.test(message)) {
+      return { ok: false, error: { code: "expired", message } };
+    }
+    if (/audience/i.test(message)) {
+      return { ok: false, error: { code: "invalid_audience", message } };
+    }
     return { ok: false, error: { code: "invalid_signature", message } };
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-md",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "pnpm --filter shared build && concurrently --names agent-provider,agent-service --prefix-colors blue,magenta \"pnpm --filter agent-providers dev\" \"pnpm --filter agent-services dev\"",


### PR DESCRIPTION
- [ ] I have QA'd the changes

## Stack

1. **#8** ← you are here
2. #9
3. #10
4. #11
5. #12

## Summary

Separate the identity-assertion surface (`/agent/identity`, `/agent/identity/claim`) from the credential surface (`/oauth2/token`, `/oauth2/revoke`). Registration mints a service-signed `identity_assertion`; agents exchange it at the token endpoint for an access_token (RFC 7523 JWT-bearer). Credentials no longer come back from `/agent/identity` or the claim ceremony.

- Rename `/agent/auth` → `/agent/identity` (and claim sub-paths)
- Add `/oauth2/token` (RFC 7523 JWT-bearer) and `/oauth2/revoke` (RFC 7009)
- OAuth error envelope per RFC 6749 §5.2; `Cache-Control: no-store` + `Pragma: no-cache` on token-endpoint responses per RFC 6749 §5.1
- Clean up the `Registration` model: derive status, drop credential coupling at registration time
- Add service-side ES256 signing key for service-issued identity_assertions
- Discovery JSON: surface top-level OAuth fields; rename `agent_auth` fields to `identity_endpoint` / `claim_endpoint`; keep `revocation_uri` at the legacy `/agent/auth/revoke` path (the secevent rename comes with the next PR)
- Update READMEs and AUTH.md to describe the new two-endpoint shape