### PR TITLE
Migrate revocation channel to SET delivery (RFC 8417/8935)

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -68,7 +68,7 @@ Response shape:
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
-    "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
+    "events_endpoint": "https://auth.service.example.com/agent/event/notify",
     "identity_types_supported": ["anonymous", "identity_assertion"],
     "identity_assertion": {
       "assertion_types_supported": [
@@ -92,7 +92,7 @@ The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `toke
 - `agent_auth.skill` — the URL of this document.
 - `agent_auth.identity_endpoint` — where you POST to register (Step 3).
 - `agent_auth.claim_endpoint` — where you POST the claim invite and OTP (Step 4).
-- `agent_auth.revocation_uri` — where the provider POSTs a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) to notify the service of upstream identity events.
+- `agent_auth.events_endpoint` — where the provider POSTs a [Security Event Token (RFC 8417)](https://datatracker.ietf.org/doc/html/rfc8417) per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) push delivery to notify the service of upstream identity events. You don't call this; it tells you what to expect.
 - `agent_auth.identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
 - `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts (ID-JAG, verified email, etc.).
 - `agent_auth.events_supported` — event schemas this service can ingest (currently revocation). Informational; you don't act on these directly.
@@ -347,6 +347,6 @@ Retry policy:
 Two independent layers can kill what you're holding:
 
 - **Credential layer ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009), `revocation_endpoint`)** — agent-callable. POST `token=<access_token>&token_type_hint=access_token` (form-encoded) to the top-level `revocation_endpoint` to kill one access_token. 200 on success, idempotent. Your `identity_assertion` is intact; re-run [Step 5](#step-5--exchange-the-assertion) to mint a fresh access_token.
-- **Registration layer (`agent_auth.revocation_uri`)** — provider-driven. The provider that minted your ID-JAG can POST a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) (`Content-Type: application/logout+jwt`) to this service's `revocation_uri`. The service invalidates the identity assertion and every access_token derived from it. You don't call this; you discover it the next time `/oauth2/token` returns `invalid_grant` — restart at [Step 3](#step-3--register).
+- **Registration layer ([RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) Security Event Token delivery, `agent_auth.events_endpoint`)** — provider-driven. The provider that minted your ID-JAG can POST a [SET (RFC 8417)](https://datatracker.ietf.org/doc/html/rfc8417) (`Content-Type: application/secevent+jwt`) to this service's `events_endpoint`. The service invalidates the identity assertion and every access_token derived from it. You don't call this; you discover it the next time `/oauth2/token` returns `invalid_grant` — restart at [Step 3](#step-3--register).
 
 On a 401 for a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once. If `/oauth2/token` succeeds, the credential was revoked at the credential layer and your fresh access_token works. If `/oauth2/token` returns `invalid_grant`, the registration was killed at the registration layer — restart at [Step 3](#step-3--register).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
 # auth.md Changelog
 
-## v0.2.0 (2026-06-04)
+## v0.3.0 (2026-06-04)
 
-Separates the identity and credential surfaces. Registration now mints a service-signed `identity_assertion` that the agent exchanges for an access_token at a standard OAuth token endpoint, instead of having `/agent/auth` issue credentials directly. Aligns the access-token issuance, revocation, discovery, and provider-driven invalidation surfaces with the standards they were already adjacent to (RFC 7523, RFC 7009, RFC 8414, RFC 6749, RFC 8417, RFC 8935).
+Switches the provider-driven invalidation channel from OIDC Back-Channel Logout to [RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417) Security Event Token push delivery per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935). Same trust path as before (issuer JWKS, jti replay protection), with a wire format and event shape that generalizes beyond revocation.
+
+### Added
+
+- `agent_auth.events_supported` discovery field — advertises which Security Event Token schemas the service is prepared to ingest. Currently lists `https://schemas.workos.com/events/agent/auth/identity/assertion/revoked`.
+
+### Changed
+
+- Endpoint: `/agent/auth/revoke` → `/agent/event/notify`.
+- Discovery: `agent_auth.revocation_uri` → `agent_auth.events_endpoint`.
+- JWT typ: `logout+jwt` → `secevent+jwt`; Content-Type: `application/logout+jwt` → `application/secevent+jwt`.
+- Response shape: 202 Accepted on success (no body); 400 with `{ "err": "<code>", "description": "..." }` per RFC 8935 §2.4 (codes: `invalid_request`, `invalid_key`, `invalid_issuer`, `invalid_audience`, `authentication_failed`).
+- Receiver validates the `events` claim and dispatches on schema URI — only revokes for the `identity-assertion/revoked` event. Unknown schemas in the same envelope are ignored per RFC 8417 §2.2.
+
+## v0.2.0 (2026-06-03)
+
+Separates the identity and credential surfaces. Registration now mints a service-signed `identity_assertion` that the agent exchanges for an access_token at a standard OAuth token endpoint, instead of having `/agent/auth` issue credentials directly. Aligns the access-token issuance, revocation, and discovery surfaces with the standards they were already adjacent to (RFC 7523, RFC 7009, RFC 8414, RFC 6749).
 
 ### Added
 
 - `/oauth2/token` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant) — agents exchange the service-signed `identity_assertion` here for a short-lived `access_token`.
 - `/oauth2/revoke` ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)) — token revocation. Returns 200 for unknown or already-revoked tokens to prevent enumeration.
 - Service-side ES256 signing key for service-minted `identity_assertion`s; JWKS published at `/.well-known/jwks.json`.
-- `agent_auth.events_supported` discovery field — advertises which Security Event Token schemas the service is prepared to ingest. Currently lists `https://schemas.workos.com/events/agent/auth/identity/assertion/revoked`.
 
 ### Changed
 
@@ -17,12 +32,6 @@ Separates the identity and credential surfaces. Registration now mints a service
 - All three registration flows (anonymous, ID-JAG, verified-email) now return a service-signed `identity_assertion` instead of an access_token. Credentials are obtained by exchanging the assertion at `/oauth2/token`.
 - Discovery (`/.well-known/oauth-authorization-server`) surfaces the top-level [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) fields (`issuer`, `token_endpoint`, `revocation_endpoint`, `grant_types_supported`) alongside the existing `agent_auth` block. Inside `agent_auth`, `register_uri` / `claim_uri` are renamed to `identity_endpoint` / `claim_endpoint`.
 - Token-endpoint error responses follow the [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) envelope (`error` / `error_description`), and successful responses carry `Cache-Control: no-store` + `Pragma: no-cache` per [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
-- Provider-driven invalidation switched from OIDC Back-Channel Logout to [RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417) Security Event Token push delivery per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935):
-  - Endpoint: `/agent/auth/revoke` → `/agent/event/notify`.
-  - Discovery: `agent_auth.revocation_uri` → `agent_auth.events_endpoint`.
-  - JWT typ: `logout+jwt` → `secevent+jwt`; Content-Type: `application/logout+jwt` → `application/secevent+jwt`.
-  - Response shape: 202 Accepted on success (no body); 400 with `{ "err": "<code>", "description": "..." }` per RFC 8935 §2.4 (codes: `invalid_request`, `invalid_key`, `invalid_issuer`, `invalid_audience`, `authentication_failed`).
-  - Receiver validates the `events` claim and dispatches on schema URI — only revokes for the `identity-assertion/revoked` event. Unknown schemas in the same envelope are ignored per RFC 8417 §2.2.
 - [bug fix] Anonymous registrations stay on pre-claim scopes for the full duration of the claim ceremony — previously the scope cap dropped as soon as the agent called `/agent/identity/claim`, before the user had confirmed ownership.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # auth.md Changelog
 
-## v0.3.0 (2026-06-04)
+## v0.3.0 (2026-06-03)
 
 Switches the provider-driven invalidation channel from OIDC Back-Channel Logout to [RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417) Security Event Token push delivery per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935). Same trust path as before (issuer JWKS, jti replay protection), with a wire format and event shape that generalizes beyond revocation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # auth.md Changelog
 
-## v0.2.0 (2026-06-03)
+## v0.2.0 (2026-06-04)
 
-Separates the identity and credential surfaces. Registration now mints a service-signed `identity_assertion` that the agent exchanges for an access_token at a standard OAuth token endpoint, instead of having `/agent/auth` issue credentials directly. Aligns the access-token issuance, revocation, and discovery surfaces with the standards they were already adjacent to (RFC 7523, RFC 7009, RFC 8414, RFC 6749).
+Separates the identity and credential surfaces. Registration now mints a service-signed `identity_assertion` that the agent exchanges for an access_token at a standard OAuth token endpoint, instead of having `/agent/auth` issue credentials directly. Aligns the access-token issuance, revocation, discovery, and provider-driven invalidation surfaces with the standards they were already adjacent to (RFC 7523, RFC 7009, RFC 8414, RFC 6749, RFC 8417, RFC 8935).
 
 ### Added
 
 - `/oauth2/token` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant) — agents exchange the service-signed `identity_assertion` here for a short-lived `access_token`.
 - `/oauth2/revoke` ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)) — token revocation. Returns 200 for unknown or already-revoked tokens to prevent enumeration.
 - Service-side ES256 signing key for service-minted `identity_assertion`s; JWKS published at `/.well-known/jwks.json`.
+- `agent_auth.events_supported` discovery field — advertises which Security Event Token schemas the service is prepared to ingest. Currently lists `https://schemas.workos.com/events/agent/auth/identity/assertion/revoked`.
 
 ### Changed
 
@@ -16,6 +17,12 @@ Separates the identity and credential surfaces. Registration now mints a service
 - All three registration flows (anonymous, ID-JAG, verified-email) now return a service-signed `identity_assertion` instead of an access_token. Credentials are obtained by exchanging the assertion at `/oauth2/token`.
 - Discovery (`/.well-known/oauth-authorization-server`) surfaces the top-level [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) fields (`issuer`, `token_endpoint`, `revocation_endpoint`, `grant_types_supported`) alongside the existing `agent_auth` block. Inside `agent_auth`, `register_uri` / `claim_uri` are renamed to `identity_endpoint` / `claim_endpoint`.
 - Token-endpoint error responses follow the [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) envelope (`error` / `error_description`), and successful responses carry `Cache-Control: no-store` + `Pragma: no-cache` per [§5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
+- Provider-driven invalidation switched from OIDC Back-Channel Logout to [RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417) Security Event Token push delivery per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935):
+  - Endpoint: `/agent/auth/revoke` → `/agent/event/notify`.
+  - Discovery: `agent_auth.revocation_uri` → `agent_auth.events_endpoint`.
+  - JWT typ: `logout+jwt` → `secevent+jwt`; Content-Type: `application/logout+jwt` → `application/secevent+jwt`.
+  - Response shape: 202 Accepted on success (no body); 400 with `{ "err": "<code>", "description": "..." }` per RFC 8935 §2.4 (codes: `invalid_request`, `invalid_key`, `invalid_issuer`, `invalid_audience`, `authentication_failed`).
+  - Receiver validates the `events` claim and dispatches on schema URI — only revokes for the `identity-assertion/revoked` event. Unknown schemas in the same envelope are ignored per RFC 8417 §2.2.
 - [bug fix] Anonymous registrations stay on pre-claim scopes for the full duration of the claim ceremony — previously the scope cap dropped as soon as the agent called `/agent/identity/claim`, before the user had confirmed ownership.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hosted at `/.well-known/oauth-authorization-server`:
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
-    "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
+    "events_endpoint": "https://auth.service.example.com/agent/event/notify",
     "identity_types_supported": ["anonymous", "identity_assertion"],
     "identity_assertion": {
       "assertion_types_supported": [

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -81,7 +81,7 @@ Discovery is two-hop:
        "skill": "https://service.example.com/auth.md",
        "identity_endpoint": "https://auth.service.example.com/agent/identity",
        "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
-       "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
+       "events_endpoint": "https://auth.service.example.com/agent/event/notify",
        "identity_types_supported": ["anonymous", "identity_assertion"],
        "identity_assertion": {
          "assertion_types_supported": [
@@ -96,7 +96,7 @@ Discovery is two-hop:
    }
    ```
 
-   The top-level `token_endpoint`, `revocation_endpoint`, and `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block carries the profile-specific bootstrap, claim, and revocation endpoints.
+   The top-level `token_endpoint`, `revocation_endpoint`, and `grant_types_supported` are standard [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) / [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) fields. The `agent_auth` block carries the profile-specific bootstrap, claim, and SET-receive endpoints.
 
 ### Minting the Identity Assertion
 
@@ -233,16 +233,16 @@ Services will reject ID-JAGs with neither a verified email nor a verified phone 
 
 ## Tracking and Revocation
 
-In a robust implementation, agent providers will want to track the services to which identity assertions have been delegated so that the user can revoke the credentials if needed from a control plane. The discovery document and the API response both contain the endpoint for revoking the assertion. The mechanism is a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html):
+In a robust implementation, agent providers will want to track the services to which identity assertions have been delegated so that the user can revoke the delegation if needed from a control plane. The discovery document's `agent_auth.events_endpoint` is where the provider transmits identity-event SETs to the service. Transmission is the canonical [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) push-based delivery of a [Security Event Token (RFC 8417)](https://datatracker.ietf.org/doc/html/rfc8417):
 
 ```json
-POST /agent/auth/revoke HTTP/1.1
+POST /agent/event/notify HTTP/1.1
 Host: auth.service.example.com
-Content-Type: application/logout+jwt
+Content-Type: application/secevent+jwt
 
 // header
 {
-  "typ": "logout+jwt",
+  "typ": "secevent+jwt",
   "alg": "ES256", // or RS256, etc.
   "kid": "<provider key id>"
 }
@@ -260,6 +260,8 @@ Content-Type: application/logout+jwt
 }
 ```
 
-Receiving services invalidate credentials associated with the ID-JAG.
+The receiving service validates the SET against the provider's JWKS, dispatches on the `events` claim, and invalidates the identity assertion (and the credentials derived from it). Per RFC 8935 §2.4, a successful receive returns 202 Accepted; failures return 400 with `{ "err": "<code>", "description": "..." }`.
 
-In a future state, we expect the need for [SET](https://datatracker.ietf.org/doc/html/rfc8417) / [CAEP](https://openid.net/specs/openid-caep-1_0-final.html) / RISC event communication between the agent providers and the consuming services, via webhook or SSE.
+Note that this `events_endpoint` is distinct from the top-level `revocation_endpoint`. The `revocation_endpoint` ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)) is for the agent or admin to kill a single bearer credential by value. The `events_endpoint` is for the provider to notify the service of an upstream identity event — a broader signal that invalidates the registration itself.
+
+In a future state, we expect richer [SET](https://datatracker.ietf.org/doc/html/rfc8417) / [CAEP](https://openid.net/specs/openid-caep-1_0-final.html) / RISC event communication between agent providers and consuming services, layered on this same push-based SET delivery channel.

--- a/agent-providers/src/jwts.ts
+++ b/agent-providers/src/jwts.ts
@@ -47,7 +47,7 @@ export async function mintIdJag(input: IdJagInput): Promise<IdJagResult> {
   return { jwt, jti, expiresIn };
 }
 
-export async function mintLogoutJwt(input: {
+export async function mintSecEventJwt(input: {
   user: User;
   audience: string;
 }): Promise<string> {
@@ -61,5 +61,5 @@ export async function mintLogoutJwt(input: {
         {},
     },
   };
-  return sign(payload, "logout+jwt");
+  return sign(payload, "secevent+jwt");
 }

--- a/agent-providers/src/routes/grants.ts
+++ b/agent-providers/src/routes/grants.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { requireSession } from "../auth.js";
-import { mintLogoutJwt } from "../jwts.js";
+import { mintSecEventJwt } from "../jwts.js";
 import { createGrantBody, parseBody } from "../schemas.js";
 import { grants, listGrantsForUser, upsertGrant } from "../store.js";
 
@@ -16,7 +16,7 @@ grantsRouter.post("/grants", requireSession, (req, res) => {
     userId: req.user!.id,
     audience: parsed.value.audience,
     mode: parsed.value.mode,
-    revocationUri: parsed.value.revocation_uri,
+    eventsUri: parsed.value.events_uri,
   });
   res.status(201).json(grant);
 });
@@ -34,33 +34,37 @@ grantsRouter.delete("/grants/:id", requireSession, async (req, res) => {
     return;
   }
 
-  if (grant.revocation_uri) {
+  if (grant.events_uri) {
     let resp: Response;
     try {
-      const logoutJwt = await mintLogoutJwt({
+      const setJwt = await mintSecEventJwt({
         user: req.user!,
         audience: grant.audience,
       });
-      resp = await fetch(grant.revocation_uri, {
+      resp = await fetch(grant.events_uri, {
         method: "POST",
-        headers: { "content-type": "application/logout+jwt" },
-        body: logoutJwt,
+        headers: { "content-type": "application/secevent+jwt" },
+        body: setJwt,
       });
     } catch (err) {
       console.warn("[revocation] outbound call failed:", err);
       res.status(500).json({
         error: "revocation_failed",
-        message: `Failed to reach ${grant.revocation_uri}. Grant retained.`,
+        message: `Failed to reach ${grant.events_uri}. Grant retained.`,
       });
       return;
     }
+    /*
+     * RFC 8935 §2.4: success is 202 Accepted. Treat any non-2xx as a
+     * delivery failure and keep the grant on file so the user can retry.
+     */
     if (!resp.ok) {
       console.warn(
-        `[revocation] ${grant.revocation_uri} responded ${resp.status}; grant retained`,
+        `[revocation] ${grant.events_uri} responded ${resp.status}; grant retained`,
       );
       res.status(500).json({
         error: "revocation_failed",
-        message: `${grant.revocation_uri} responded ${resp.status}. Grant retained.`,
+        message: `${grant.events_uri} responded ${resp.status}. Grant retained.`,
       });
       return;
     }

--- a/agent-providers/src/routes/home.ts
+++ b/agent-providers/src/routes/home.ts
@@ -93,8 +93,8 @@ function renderHtml(seeded: { email: string; name: string }[]): string {
       <option value="once">once — marked consumed on first mint</option>
     </select>
   </label>
-  <label>Revocation URI (optional)
-    <input id="grant-revoke" value="${config.consumerUrl}/agent/auth/revoke" placeholder="${config.consumerUrl}/agent/auth/revoke">
+  <label>Events URI (optional)
+    <input id="grant-revoke" value="${config.consumerUrl}/agent/event/notify" placeholder="${config.consumerUrl}/agent/event/notify">
   </label>
   <div class="label">Request</div>
   <div class="req" id="grant-req"><pre></pre></div>
@@ -139,7 +139,7 @@ function renderHtml(seeded: { email: string; name: string }[]): string {
 
 <section id="step-6" hidden>
   <h2><span class="num">6</span>Revoke grant</h2>
-  <p>Deleting a grant removes it locally. If a <code>revocation_uri</code> was recorded, the provider first POSTs a <code>logout+jwt</code> there; if the call fails, the grant is retained and the endpoint returns 500. Any credentials the consumer issued for this delegation are invalidated.</p>
+  <p>Deleting a grant removes it locally. If an <code>events_uri</code> was recorded, the provider first POSTs a <code>secevent+jwt</code> (RFC 8417 SET, delivered per RFC 8935) there; if the call fails, the grant is retained and the endpoint returns 500. Any credentials the consumer issued for this delegation are invalidated.</p>
   <div class="label">Request</div>
   <div class="req" id="revoke-req"><pre></pre></div>
   <button class="primary" type="button" data-action="revoke">Revoke</button>
@@ -227,7 +227,7 @@ function updateGrantPreview() {
     mode: document.getElementById("grant-mode").value,
   };
   const rev = document.getElementById("grant-revoke").value.trim();
-  if (rev) body.revocation_uri = rev;
+  if (rev) body.events_uri = rev;
   document.querySelector("#grant-req pre").textContent =
     "POST /grants\\nAuthorization: Bearer <session>\\n\\n" + jsonStr(body);
 }
@@ -299,7 +299,7 @@ async function grant() {
     mode: document.getElementById("grant-mode").value,
   };
   const rev = document.getElementById("grant-revoke").value.trim();
-  if (rev) body.revocation_uri = rev;
+  if (rev) body.events_uri = rev;
 
   const r = await jsonFetch("/grants", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("grant-out").innerHTML = resBlock(r.status, r.body, r.ok);
@@ -454,7 +454,7 @@ async function revoke() {
 
   // If a credential was exchanged at the consumer, prove it's now rejected.
   // A 401 here is the expected outcome — it confirms the consumer processed
-  // the logout+jwt. A 200 would mean revocation didn't take effect.
+  // the SET. A 200 would mean revocation didn't take effect.
   if (state.credential) {
     const url = state.audience + "/api/resource";
     try {

--- a/agent-providers/src/schemas.ts
+++ b/agent-providers/src/schemas.ts
@@ -7,7 +7,7 @@ export const loginBody = z.object({
 export const createGrantBody = z.object({
   audience: z.url(),
   mode: z.enum(["once", "always"]),
-  revocation_uri: z.url().optional(),
+  events_uri: z.url().optional(),
 });
 
 export const mintIdJagBody = z.object({

--- a/agent-providers/src/store.ts
+++ b/agent-providers/src/store.ts
@@ -28,7 +28,8 @@ export type Grant = {
   created_at: Date;
   expires_at: Date;
   consumed_at?: Date;
-  revocation_uri?: string;
+  /** Consumer's `agent_auth.events_endpoint` — where we POST SETs on revoke. */
+  events_uri?: string;
 };
 
 function addSeconds(base: Date, seconds: number): Date {
@@ -95,14 +96,14 @@ export function upsertGrant(input: {
   userId: string;
   audience: string;
   mode: GrantMode;
-  revocationUri?: string;
+  eventsUri?: string;
 }): Grant {
   const now = new Date();
   const existing = findGrantForAudience(input.userId, input.audience);
   if (existing) {
     existing.mode = input.mode;
     existing.expires_at = addSeconds(now, config.consentTtlSeconds);
-    if (input.revocationUri) existing.revocation_uri = input.revocationUri;
+    if (input.eventsUri) existing.events_uri = input.eventsUri;
     return existing;
   }
   const grant: Grant = {
@@ -112,7 +113,7 @@ export function upsertGrant(input: {
     mode: input.mode,
     created_at: now,
     expires_at: addSeconds(now, config.consentTtlSeconds),
-    revocation_uri: input.revocationUri,
+    events_uri: input.eventsUri,
   };
   grants.set(grant.id, grant);
   return grant;

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -103,7 +103,7 @@ To participate as a consumer service, you should:
 3. Host `/agent/identity` (and its `/claim` sub-endpoints) that dispatches on `type` and returns a service-signed `identity_assertion`
 4. Host `/oauth2/token` (RFC 7523 JWT-bearer) that exchanges the `identity_assertion` for an access_token
 5. Host `/oauth2/revoke` (RFC 7009) for agent-initiated credential revocation
-6. Accept provider-initiated logout tokens at the advertised `revocation_uri`
+6. Accept provider-initiated Security Event Tokens (RFC 8417) at the advertised `events_endpoint`
 7. Maintain a trust list of agent providers (for `identity_assertion`)
 8. Verify ID-JAG signatures against the provider's JWKS and enforce claim checks
 9. Record audit events for every state change in the flow
@@ -146,7 +146,7 @@ AS metadata:
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
-    "revocation_uri": "https://auth.service.example.com/agent/auth/revoke",
+    "events_endpoint": "https://auth.service.example.com/agent/event/notify",
     "identity_types_supported": ["anonymous", "identity_assertion"],
     "identity_assertion": {
       "assertion_types_supported": [
@@ -161,7 +161,7 @@ AS metadata:
 }
 ```
 
-Top-level `issuer` / `token_endpoint` / `revocation_endpoint` / `grant_types_supported` follow [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) (with `revocation_endpoint` per [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). The `agent_auth` block is a profile extension for the agent-auth–specific surface: the registration endpoint, the claim ceremony, and the revocation-receive endpoint.
+Top-level `issuer` / `token_endpoint` / `revocation_endpoint` / `grant_types_supported` follow [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) (with `revocation_endpoint` per [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). The `agent_auth` block is a profile extension for the agent-auth–specific surface: the registration endpoint, the claim ceremony, and the [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) SET receiver.
 
 Advertise the identity types and assertion types your service accepts. Anonymous is the simplest if you only support self-registration; ID-JAG is for trusted-provider integrations; the verified email assertion type is for agents that have a user email but no provider-signed assertion.
 
@@ -354,7 +354,7 @@ Implementation:
 - Return 200 even when the token is unknown or already revoked ([RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) — prevents enumeration).
 - Return 400 with `{ "error": "invalid_request", "error_description": "..." }` only when the body itself is malformed.
 
-The agent's `identity_assertion` is unaffected — they can immediately re-call `/oauth2/token` to mint a fresh access_token. To kill the underlying registration, the provider uses the legacy logout-token mechanism at `revocation_uri` (see [Revocation](#revocation)).
+The agent's `identity_assertion` is unaffected — they can immediately re-call `/oauth2/token` to mint a fresh access_token. To kill the underlying registration, the provider POSTs a SET to the `events_endpoint` (see [Revocation](#revocation)).
 
 ### Verifying ID-JAGs
 
@@ -494,14 +494,21 @@ Implementation notes:
 
 ### Revocation
 
-Accept logout tokens at the `revocation_uri` advertised in your discovery document. The provider signs a [logout token](https://openid.net/specs/openid-connect-backchannel-1_0.html) referencing the delegation to revoke:
+Revocation has two distinct surfaces:
+
+1. **Agent or admin invalidating a specific credential** — RFC 7009 token revocation at the top-level `revocation_endpoint` (covered in [POST /oauth2/revoke](#post-oauth2revoke--rfc-7009-token-revocation)).
+2. **Provider notifying the service of an upstream identity event** — RFC 8935 push-based delivery of a [Security Event Token](https://datatracker.ietf.org/doc/html/rfc8417) to the `agent_auth.events_endpoint`.
+
+#### POST /agent/event/notify — RFC 8935 SET receiver
+
+Providers transmit a signed Security Event Token to deliver identity events (logout, unlink, etc.). The SET's `events` claim names one or more schema URIs identifying the event types in this envelope:
 
 ```
-POST /agent/auth/revoke HTTP/1.1
+POST /agent/event/notify HTTP/1.1
 Host: auth.service.example.com
-Content-Type: application/logout+jwt
+Content-Type: application/secevent+jwt
 
-{ "typ": "logout+jwt", "alg", "kid" }
+{ "typ": "secevent+jwt", "alg", "kid" }
 .
 {
   "iss": "https://api.agent-provider.example.com",
@@ -517,12 +524,15 @@ Content-Type: application/logout+jwt
 
 On receipt:
 
-1. Verify the logout token's signature against the issuer's JWKS (same trust path as ID-JAG verification).
-2. Enforce `jti` uniqueness for replay protection.
-3. Find all credentials issued for `(iss, sub, aud)` and invalidate them.
-4. Return 200 on success, 400 on verification failure.
+1. Verify the SET signature against the issuer's JWKS (same trust path as ID-JAG verification).
+2. Validate `iss` against the trust list, `aud` against your service, and enforce `jti` uniqueness for replay protection.
+3. Dispatch on each entry in the `events` claim — for the `identity-assertion-revoked` schema, find all credentials issued for `(iss, sub, aud)` and invalidate them. Unknown event schemas can be safely ignored ([RFC 8417 §2.2](https://datatracker.ietf.org/doc/html/rfc8417#section-2.2)).
+4. Return 202 Accepted on success, with no body.
+5. On failure, return 400 with `{ "err": "<code>", "description": "..." }` per [RFC 8935 §2.4](https://datatracker.ietf.org/doc/html/rfc8935#section-2.4). Defined error codes: `invalid_request`, `invalid_key`, `invalid_issuer`, `invalid_audience`, `authentication_failed`.
 
-In a future state, expect to extend this surface with [SET](https://datatracker.ietf.org/doc/html/rfc8417) / [CAEP](https://openid.net/specs/openid-caep-1_0-final.html) / RISC event communication for session changes beyond revocation, delivered via webhook or SSE.
+The same endpoint can accept additional event types in the future (account suspended, claims updated, etc.) by adding entries to your dispatch table — providers don't need to coordinate; the `events_supported` array in your discovery doc advertises which schemas you're prepared to handle.
+
+A future evolution of this surface is the OpenID [Shared Signals Framework](https://openid.net/specs/openid-sharedsignals-framework-1_0.html) — a stream-management protocol on top of RFC 8935 with subject subscriptions and polling. Today we accept push-only and don't expose stream management.
 
 ### Rate Limiting
 
@@ -547,7 +557,7 @@ Record the following state transitions for observability and incident response. 
 | `otp.generated`        | OTP minted for the claim view                               | `registration_id`                       |
 | `claim.confirmed`      | `/agent/identity/claim/complete` succeeds                   | `registration_id`, `claimed_by_user_id` |
 | `registration.expired` | Unclaimed registration past its TTL                         | `registration_id`                       |
-| `registration.revoked` | Logout token processed                                      | `registration_id`, `iss`, `sub`         |
+| `registration.revoked` | SET processed at `/agent/event/notify`                      | `registration_id`, `iss`, `sub`         |
 
 For ID-JAG flows, include `iss`, `sub`, `agent_platform`, and `agent_context_id` so operators can correlate with provider-side logs.
 

--- a/agent-services/src/config.ts
+++ b/agent-services/src/config.ts
@@ -31,8 +31,8 @@ export const config = Object.freeze({
   identityEndpointPath: "/agent/identity",
   /** Claim ceremony endpoint, nested under identity. */
   claimEndpointPath: "/agent/identity/claim",
-  /** Legacy logout-token receiver path. */
-  revocationUriPath: "/agent/auth/revoke",
+  /** RFC 8935 SET receiver path (provider-pushed identity events). */
+  eventsEndpointPath: "/agent/event/notify",
   corsOrigins: [providerUrl],
   mailDir: ".mail",
   mailUrlPath: "/mail",

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -585,17 +585,34 @@ agentAuthRouter.post(
       res.status(400).json({ err, description });
       return;
     }
-    const count = revokeForDelegation(
-      verified.claims.iss,
-      verified.claims.sub,
-      verified.claims.aud,
-    );
-    console.log(
-      `[agent-auth] revoked ${count} credentials for iss=${verified.claims.iss} sub=${verified.claims.sub}`,
-    );
+    /*
+     * Dispatch on the SET's `events` schema URIs. We only handle the
+     * identity-assertion revocation event today; per RFC 8417 §2.2, any
+     * unknown schemas in the same envelope are silently ignored (we still
+     * 202 the delivery — the SET was well-formed, we just had nothing to
+     * do for it).
+     */
+    const schemas = Object.keys(verified.claims.events);
+    if (schemas.includes(IDENTITY_ASSERTION_REVOKED_SCHEMA)) {
+      const count = revokeForDelegation(
+        verified.claims.iss,
+        verified.claims.sub,
+        verified.claims.aud,
+      );
+      console.log(
+        `[agent-auth] revoked ${count} credentials for iss=${verified.claims.iss} sub=${verified.claims.sub}`,
+      );
+    } else {
+      console.log(
+        `[agent-auth] SET from ${verified.claims.iss} carried no recognized events (${schemas.join(", ")}); no-op`,
+      );
+    }
     res.status(202).end();
   },
 );
+
+export const IDENTITY_ASSERTION_REVOKED_SCHEMA =
+  "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked";
 
 /**
  * Map our internal verify error codes onto the SET delivery error codes

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -22,7 +22,12 @@ import {
   revokeForDelegation,
   sha256Hex,
 } from "../store.js";
-import { signServiceIdJag, verifyIdJag, verifyLogoutJwt } from "../verify.js";
+import {
+  type VerifyError,
+  signServiceIdJag,
+  verifyIdJag,
+  verifySecEventJwt,
+} from "../verify.js";
 
 /*
  * Agent-facing endpoints implementing the OTP-exchange flavor of the
@@ -554,24 +559,30 @@ function escapeHtml(s: string): string {
   );
 }
 
+/*
+ * RFC 8935 SET receiver. Providers POST a signed Security Event Token
+ * (RFC 8417) here to invalidate the registration and credentials tied to
+ * the (iss, sub, aud) triple in the SET. Response shape follows RFC 8935
+ * §2.4 — 202 Accepted with no body on success; 400 with { err, description }
+ * on failure (note: "err"/"description", not "error"/"message").
+ */
 agentAuthRouter.post(
-  config.revocationUriPath,
-  express.text({ type: "application/logout+jwt" }),
+  config.eventsEndpointPath,
+  express.text({ type: "application/secevent+jwt" }),
   async (req, res) => {
     const token = typeof req.body === "string" ? req.body.trim() : "";
     if (!token) {
       res.status(400).json({
-        error: "invalid_request",
-        message: "Expected JWT body with Content-Type application/logout+jwt.",
+        err: "invalid_request",
+        description:
+          "Expected JWT body with Content-Type application/secevent+jwt.",
       });
       return;
     }
-    const verified = await verifyLogoutJwt(token);
+    const verified = await verifySecEventJwt(token);
     if (!verified.ok) {
-      res.status(400).json({
-        error: verified.error.code,
-        message: verified.error.message,
-      });
+      const { err, description } = mapSecEventError(verified.error);
+      res.status(400).json({ err, description });
       return;
     }
     const count = revokeForDelegation(
@@ -582,6 +593,28 @@ agentAuthRouter.post(
     console.log(
       `[agent-auth] revoked ${count} credentials for iss=${verified.claims.iss} sub=${verified.claims.sub}`,
     );
-    res.json({ revoked: count });
+    res.status(202).end();
   },
 );
+
+/**
+ * Map our internal verify error codes onto the SET delivery error codes
+ * defined in RFC 8935 §2.4: invalid_request, invalid_key, invalid_issuer,
+ * invalid_audience, authentication_failed.
+ */
+function mapSecEventError(error: VerifyError): {
+  err: string;
+  description: string;
+} {
+  switch (error.code) {
+    case "invalid_issuer":
+      return { err: "invalid_issuer", description: error.message };
+    case "invalid_audience":
+      return { err: "invalid_audience", description: error.message };
+    case "invalid_signature":
+    case "expired":
+      return { err: "authentication_failed", description: error.message };
+    default:
+      return { err: "invalid_request", description: error.message };
+  }
+}

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -262,7 +262,7 @@ Content-Type: application/json
   <div class="req" id="call-req"><pre></pre></div>
   <button class="primary" type="button" data-action="call">Call /api/resource</button>
   <div id="call-out"></div>
-  <p class="note" style="margin-top:1rem">Revocation has two surfaces. RFC 7009 token revocation at <code>/oauth2/revoke</code> kills one access_token; the agent can re-exchange the identity_assertion to mint a fresh one. The provider can also POST a <code>logout+jwt</code> to <code>/agent/auth/revoke</code>, which invalidates all credentials for the <code>(iss, sub, aud)</code> — see the provider demo's revoke step.</p>
+  <p class="note" style="margin-top:1rem">Revocation has two surfaces. RFC 7009 token revocation at <code>/oauth2/revoke</code> kills one access_token; the agent can re-exchange the identity_assertion to mint a fresh one. The provider can also POST a <code>secevent+jwt</code> (RFC 8417 SET, delivered per RFC 8935) to <code>/agent/event/notify</code>, which invalidates all credentials for the <code>(iss, sub, aud)</code> — see the provider demo's revoke step.</p>
 </section>
 </div>
 </div>

--- a/agent-services/src/routes/well-known.ts
+++ b/agent-services/src/routes/well-known.ts
@@ -32,7 +32,7 @@ wellKnownRouter.get("/.well-known/oauth-authorization-server", (_req, res) => {
       skill: `${config.baseUrl}/auth.md`,
       identity_endpoint: `${config.baseUrl}${config.identityEndpointPath}`,
       claim_endpoint: `${config.baseUrl}${config.claimEndpointPath}`,
-      revocation_uri: `${config.baseUrl}${config.revocationUriPath}`,
+      events_endpoint: `${config.baseUrl}${config.eventsEndpointPath}`,
       identity_types_supported: ["anonymous", "identity_assertion"],
       identity_assertion: {
         assertion_types_supported: [

--- a/agent-services/src/routes/well-known.ts
+++ b/agent-services/src/routes/well-known.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { config } from "../config.js";
+import { IDENTITY_ASSERTION_REVOKED_SCHEMA } from "./agent-auth.js";
 
 export const wellKnownRouter = Router();
 
@@ -40,9 +41,7 @@ wellKnownRouter.get("/.well-known/oauth-authorization-server", (_req, res) => {
           "verified_email",
         ],
       },
-      events_supported: [
-        "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked",
-      ],
+      events_supported: [IDENTITY_ASSERTION_REVOKED_SCHEMA],
     },
   });
 });

--- a/agent-services/src/verify.ts
+++ b/agent-services/src/verify.ts
@@ -137,7 +137,12 @@ export async function verifyIdJag(
   return { ok: true, claims };
 }
 
-export type LogoutClaims = JWTPayload & {
+/**
+ * RFC 8417 Security Event Token (SET). Pushed by trusted providers to the
+ * service's `events_endpoint` to invalidate registrations and credentials
+ * tied to an upstream identity event.
+ */
+export type SecEventClaims = JWTPayload & {
   iss: string;
   sub: string;
   aud: string;
@@ -145,10 +150,10 @@ export type LogoutClaims = JWTPayload & {
   events: Record<string, unknown>;
 };
 
-export async function verifyLogoutJwt(
+export async function verifySecEventJwt(
   jwt: string,
 ): Promise<
-  { ok: true; claims: LogoutClaims } | { ok: false; error: VerifyError }
+  { ok: true; claims: SecEventClaims } | { ok: false; error: VerifyError }
 > {
   const iss = peekIssuer(jwt);
   if (!iss || !isTrustedIssuer(iss)) {
@@ -164,10 +169,10 @@ export async function verifyLogoutJwt(
     const res = await jwtVerify(jwt, getJwks(iss), {
       issuer: iss,
       audience: config.baseUrl,
-      typ: "logout+jwt",
+      typ: "secevent+jwt",
       clockTolerance: config.clockSkewSeconds,
     });
-    const claims = res.payload as LogoutClaims;
+    const claims = res.payload as SecEventClaims;
     if (!claims.jti || !claims.sub) {
       return {
         ok: false,

--- a/agent-services/src/verify.ts
+++ b/agent-services/src/verify.ts
@@ -182,6 +182,26 @@ export async function verifySecEventJwt(
         },
       };
     }
+    /*
+     * RFC 8417 §2.1: `events` is REQUIRED and is a JSON object whose keys
+     * are event-type schema URIs. Reject anything that isn't a non-empty
+     * object so the dispatch step downstream has something real to match
+     * against.
+     */
+    if (
+      typeof claims.events !== "object" ||
+      claims.events === null ||
+      Array.isArray(claims.events) ||
+      Object.keys(claims.events).length === 0
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_request",
+          message: "SET must include a non-empty events claim (RFC 8417 §2.1).",
+        },
+      };
+    }
     const replay = recordJti(
       claims.jti,
       claims.exp ?? Math.floor(Date.now() / 1000) + 300,

--- a/agent-services/src/verify.ts
+++ b/agent-services/src/verify.ts
@@ -218,6 +218,12 @@ export async function verifySecEventJwt(
     return { ok: true, claims };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (/expired|exp/i.test(message)) {
+      return { ok: false, error: { code: "expired", message } };
+    }
+    if (/audience/i.test(message)) {
+      return { ok: false, error: { code: "invalid_audience", message } };
+    }
     return { ok: false, error: { code: "invalid_signature", message } };
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-md",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "pnpm --filter shared build && concurrently --names agent-provider,agent-service --prefix-colors blue,magenta \"pnpm --filter agent-providers dev\" \"pnpm --filter agent-services dev\"",


### PR DESCRIPTION
- [ ] I have QA'd the changes

## Stack

1. #8 
2. **#9** ← you are here
3. #10
4. #11
5. #12

## Summary

Switch the provider-driven invalidation channel from a logout-token at `agent_auth.revocation_uri` to a Security Event Token ([RFC 8417](https://datatracker.ietf.org/doc/html/rfc8417)) delivered via push ([RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935)) at `agent_auth.events_endpoint`. The discovery field, endpoint path, JWT typ, content-type, and response shape all switch together.

- Discovery: `agent_auth.revocation_uri` → `agent_auth.events_endpoint`
- Endpoint: `/agent/auth/revoke` → `/agent/event/notify`
- JWT typ: `logout+jwt` → `secevent+jwt`; Content-Type: `application/logout+jwt` → `application/secevent+jwt`
- Receiver responses follow RFC 8935 §2.4: 202 Accepted on success (no body), 400 with `{ "err": "<code>", "description": "..." }` on failure with codes from §2.4 (`invalid_request`, `invalid_key`, `invalid_issuer`, `invalid_audience`, `authentication_failed`)
- Provider side: `mintLogoutJwt` → `mintSecEventJwt`; grant input field `revocation_uri` → `events_uri`
- Docs + demos updated end to end

The top-level OAuth `revocation_endpoint` (`/oauth2/revoke`, RFC 7009) is unrelated and stays as-is.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
