### PR TITLE
Claim anonymous registration via ID-JAG

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -262,15 +262,21 @@ The end goal: get a signed-in user to confirm a 6-digit `user_code` **you supply
 
 For **service_auth** registrations, you already have them — they're in the `claim` block of the Step 3 response. Skip to 4b.
 
-For **anonymous** registrations, ask the service to start a ceremony:
+For **anonymous** registrations, you have two options:
+
+- **login_hint shape (`type: "login_hint"`)** — start a user_code ceremony for the user identified by the login_hint. Default path; works when the agent has no provider identity.
+- **ID-JAG shape (`type: "identity_assertion"`)** — if you later acquire an ID-JAG, claim atomically without the ceremony. See [4a-alt](#4a-alt-claim-via-id-jag) below.
+
+login_hint shape:
 
 ```http
 POST /agent/identity/claim
 Content-Type: application/json
 
 {
+  "type": "login_hint",
   "claim_token": "clm_...",
-  "email": "user@example.com"
+  "login_hint": "user@example.com"
 }
 ```
 
@@ -292,6 +298,40 @@ Response (200):
 ```
 
 The `claim_attempt` block here — same shape as the `claim` block in the `service_auth` registration response — borrows from [RFC 8628 device-authorization](https://datatracker.ietf.org/doc/html/rfc8628), with `claim_attempt_token` embedded in `verification_uri` so the URL identifies the registration without leaking the user-typed `user_code`. Surface `verification_uri` + `user_code` to the user; poll the standard `token_endpoint` from AS metadata with the claim grant (see 4c).
+
+### 4a-alt. Claim via ID-JAG
+
+If you started anonymous but later acquired an ID-JAG for the user (e.g., the user signed in through your provider during the agent's run), you can claim atomically without the user-code ceremony:
+
+```http
+POST /agent/identity/claim
+Content-Type: application/json
+
+{
+  "type": "identity_assertion",
+  "claim_token": "clm_...",
+  "assertion": "<your ID-JAG JWT>"
+}
+```
+
+Response (200):
+
+```json
+{
+  "registration_id": "reg_...",
+  "status": "claimed",
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-21T18:31:25.994Z"
+}
+```
+
+Skip to [Step 5](#step-5--exchange-the-assertion) with the new `identity_assertion`.
+
+Three things can go wrong here, all 401:
+
+- **`login_required`** — the ID-JAG's `auth_time` is missing or stale. Re-authenticate at your provider and retry.
+- **`interaction_required`** — the ID-JAG matched an existing user at the service but no `(iss, sub)` delegation exists yet. Walk normal step-up at `/agent/identity` first (Step 3); the delegation gets bound by the user's confirmation there, and a retry here clean-matches.
+- **`invalid_grant`** / other ID-JAG verification errors — fix the ID-JAG (fresh `jti`, correct `aud`, etc.) and retry.
 
 The `email` you supply on anonymous `/claim` binds the registration to the human you intend the agent to act on behalf of — only that signed-in user can complete the ceremony. Without this, a third party who intercepted the `user_code` could claim the agent for themselves.
 

--- a/AUTH.md
+++ b/AUTH.md
@@ -314,7 +314,9 @@ Content-Type: application/json
 }
 ```
 
-Response (200):
+Two success shapes:
+
+**Clean match (200)** — the ID-JAG cleanly matches an existing `(iss, sub)` delegation, or matches by verified email with no conflicting existing account. The registration is bound atomically, no user confirmation needed:
 
 ```json
 {
@@ -327,11 +329,27 @@ Response (200):
 
 Skip to [Step 5](#step-5--exchange-the-assertion) with the new `identity_assertion`.
 
-Three things can go wrong here, all 401:
+**Step-up required (200)** — the ID-JAG's verified email matches an existing different user at the service and no `(iss, sub)` delegation exists yet. The service won't silently bind the delegation; surface the returned ceremony block to the user and poll `/oauth2/token` exactly as in the user-code claim flow ([Step 4b](#4b-hand-off-to-the-user) and [Step 4c](#4c-poll-for-completion)). The user signs in, confirms linking the provider identity to their account, and the next poll resolves to a post-claim access_token plus a v2 `identity_assertion`:
 
-- **`login_required`** — the ID-JAG's `auth_time` is missing or stale. Re-authenticate at your provider and retry.
-- **`interaction_required`** — the ID-JAG matched an existing user at the service but no `(iss, sub)` delegation exists yet. Walk normal step-up at `/agent/identity` first (Step 3); the delegation gets bound by the user's confirmation there, and a retry here clean-matches.
-- **`invalid_grant`** / other ID-JAG verification errors — fix the ID-JAG (fresh `jti`, correct `aud`, etc.) and retry.
+```json
+{
+  "registration_id": "reg_...",
+  "claim_attempt_id": "cla_...",
+  "status": "initiated",
+  "expires_at": "...",
+  "claim_attempt": {
+    "user_code": "123456",
+    "verification_uri": "https://auth.service.example.com/claim?claim_attempt_token=...",
+    "expires_in": 600,
+    "interval": 5
+  }
+}
+```
+
+Failures:
+
+- **`login_required` (401)** — the ID-JAG's `auth_time` is missing or stale. Re-authenticate at your provider and retry.
+- **`invalid_grant`** / other ID-JAG verification errors (400) — fix the ID-JAG (fresh `jti`, correct `aud`, etc.) and retry.
 
 The `email` you supply on anonymous `/claim` binds the registration to the human you intend the agent to act on behalf of — only that signed-in user can complete the ceremony. Without this, a third party who intercepted the `user_code` could claim the agent for themselves.
 

--- a/AUTH.md
+++ b/AUTH.md
@@ -265,7 +265,7 @@ For **service_auth** registrations, you already have them — they're in the `cl
 For **anonymous** registrations, you have two options:
 
 - **login_hint shape (`type: "login_hint"`)** — start a user_code ceremony for the user identified by the login_hint. Default path; works when the agent has no provider identity.
-- **ID-JAG shape (`type: "identity_assertion"`)** — if you later acquire an ID-JAG, claim atomically without the ceremony. See [4a-alt](#4a-alt-claim-via-id-jag) below.
+- **ID-JAG shape (`type: "identity_assertion"`)** — if you later acquire an ID-JAG, you can finish the claim straight away and skip the user_code ceremony. See [4a-alt](#4a-alt-claim-via-id-jag) below.
 
 login_hint shape:
 
@@ -316,7 +316,7 @@ Content-Type: application/json
 
 Two success shapes:
 
-**No confirmation needed (200)** — the ID-JAG is accepted on its own (either an existing `(iss, sub)` delegation, or no email conflict with another account). The registration is bound atomically:
+**No confirmation needed (200)** — the ID-JAG is enough on its own, either because there's already an `(iss, sub)` delegation for this user or because the ID-JAG's email doesn't conflict with another account at the service. The registration is bound right away:
 
 ```json
 {

--- a/AUTH.md
+++ b/AUTH.md
@@ -301,7 +301,7 @@ The `claim_attempt` block here — same shape as the `claim` block in the `servi
 
 ### 4a-alt. Claim via ID-JAG
 
-If you started anonymous but later acquired an ID-JAG for the user (e.g., the user signed in through your provider during the agent's run), you can claim atomically without the user-code ceremony:
+If you started anonymous, the user wants to claim the registration, and you can obtain an ID-JAG for them, you can bind the existing registration to that identity instead of re-registering:
 
 ```http
 POST /agent/identity/claim
@@ -316,7 +316,7 @@ Content-Type: application/json
 
 Two success shapes:
 
-**Clean match (200)** — the ID-JAG cleanly matches an existing `(iss, sub)` delegation, or matches by verified email with no conflicting existing account. The registration is bound atomically, no user confirmation needed:
+**No confirmation needed (200)** — the ID-JAG is accepted on its own (either an existing `(iss, sub)` delegation, or no email conflict with another account). The registration is bound atomically:
 
 ```json
 {
@@ -330,7 +330,7 @@ Two success shapes:
 
 Skip to [Step 5](#step-5--exchange-the-assertion) with the new `identity_assertion`.
 
-**Step-up required (200)** — the ID-JAG's verified email matches an existing different user at the service and no `(iss, sub)` delegation exists yet. The service won't silently bind the delegation; surface the returned ceremony block to the user and poll `/oauth2/token` exactly as in the user-code claim flow ([Step 4b](#4b-hand-off-to-the-user) and [Step 4c](#4c-poll-for-completion)). The user signs in, confirms linking the provider identity to their account, and the next poll resolves to a post-claim access_token plus a v2 `identity_assertion`:
+**Confirmation required (200)** — the ID-JAG's verified email matches an existing different account at the service and no `(iss, sub)` delegation exists yet. The service won't silently bind the delegation; surface the returned ceremony block to the user and poll `/oauth2/token` exactly as in the user-code claim flow ([Step 4b](#4b-hand-off-to-the-user) and [Step 4c](#4c-poll-for-completion)). The user signs in, confirms linking the provider identity to their account, and the next poll resolves to a post-claim access_token plus a v2 `identity_assertion`:
 
 ```json
 {

--- a/AUTH.md
+++ b/AUTH.md
@@ -330,7 +330,7 @@ Two success shapes:
 
 Skip to [Step 5](#step-5--exchange-the-assertion) with the new `identity_assertion`.
 
-**Confirmation required (200)** — the ID-JAG's verified email matches an existing different account at the service and no `(iss, sub)` delegation exists yet. The service won't silently bind the delegation; surface the returned ceremony block to the user and poll `/oauth2/token` exactly as in the user-code claim flow ([Step 4b](#4b-hand-off-to-the-user) and [Step 4c](#4c-poll-for-completion)). The user signs in, confirms linking the provider identity to their account, and the next poll resolves to a post-claim access_token plus a v2 `identity_assertion`:
+**Confirmation required (200)** — the ID-JAG's verified email matches an existing different account at the service and no `(iss, sub)` delegation exists yet. The service won't silently bind the delegation; surface the returned `claim_attempt` block to the user and poll `/oauth2/token` exactly as in the user-code claim flow ([Step 4b](#4b-hand-off-to-the-user) and [Step 4c](#4c-poll-for-completion)). The user signs in, confirms linking the provider identity to their account, and the next poll resolves to a post-claim access_token plus a v2 `identity_assertion`:
 
 ```json
 {

--- a/AUTH.md
+++ b/AUTH.md
@@ -321,6 +321,7 @@ Two success shapes:
 ```json
 {
   "registration_id": "reg_...",
+  "registration_type": "identity_assertion",
   "status": "claimed",
   "identity_assertion": "<service-signed JWT>",
   "assertion_expires": "2026-05-21T18:31:25.994Z"
@@ -334,6 +335,7 @@ Skip to [Step 5](#step-5--exchange-the-assertion) with the new `identity_asserti
 ```json
 {
   "registration_id": "reg_...",
+  "registration_type": "identity_assertion",
   "claim_attempt_id": "cla_...",
   "status": "initiated",
   "expires_at": "...",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # auth.md Changelog
 
+## v0.7.0 (2026-06-12)
+
+Adds a second body shape to `POST /agent/identity/claim` so an agent that started anonymous can bind its registration to a user identity by presenting an ID-JAG — skipping the user_code ceremony when the ID-JAG cleanly matches, falling back to a ceremony only when step-up is required. Keeps `registration_id` and pre-claim continuity intact instead of forcing the agent to re-register.
+
+### Added
+
+- `POST /agent/identity/claim` accepts `{ type: "identity_assertion", claim_token, assertion }` as an alternative to the existing `login_hint`-shape body. The body shape is now a discriminated union on `type`.
+- Clean-match response (200) — `{ status: "claimed", identity_assertion, assertion_expires }`. The agent skips polling and goes straight to `/oauth2/token` (jwt-bearer) with the new assertion.
+- Step-up response (200) — `{ status: "initiated", claim_attempt: { user_code, verification_uri, expires_in, interval } }`. Same ceremony shape as the `login_hint` body. The agent surfaces the code, the user confirms at `/claim`, and `/oauth2/token` (claim grant) yields the post-claim access_token.
+
+### Changed
+
+- `/agent/identity/claim` body is now a discriminated union on `type`. The previous `{ claim_token, login_hint }` shape is now `{ "type": "login_hint", claim_token, login_hint }`; existing callers must add the `"type": "login_hint"` discriminator.
+
 ## v0.6.0 (2026-06-10)
 
 Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.7.0 (2026-06-12)
 
-Adds a second body shape to `POST /agent/identity/claim` so an agent that started anonymous can bind its registration to a user identity by presenting an ID-JAG — skipping the user_code ceremony when the ID-JAG can be used without further verification, falling back to a ceremony only when confirmation is required. Keeps `registration_id` and pre-claim continuity intact instead of forcing the agent to re-register.
+Adds a second body shape to `POST /agent/identity/claim`. An agent that started anonymous can now claim its registration by presenting an ID-JAG: if the ID-JAG is enough on its own, the claim completes right there; if it isn't (the ID-JAG's email matches a different existing account), the response falls back to the user_code ceremony so the user can confirm. Either way, `registration_id` and the pre-claim credentials stay intact — no re-registration needed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.7.0 (2026-06-12)
 
-Adds a second body shape to `POST /agent/identity/claim` so an agent that started anonymous can bind its registration to a user identity by presenting an ID-JAG — skipping the user_code ceremony when the ID-JAG cleanly matches, falling back to a ceremony only when step-up is required. Keeps `registration_id` and pre-claim continuity intact instead of forcing the agent to re-register.
+Adds a second body shape to `POST /agent/identity/claim` so an agent that started anonymous can bind its registration to a user identity by presenting an ID-JAG — skipping the user_code ceremony when the ID-JAG can be used without further verification, falling back to a ceremony only when confirmation is required. Keeps `registration_id` and pre-claim continuity intact instead of forcing the agent to re-register.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ sequenceDiagram
     Note over Agent: Agent operates with pre-claim scopes
 
     User-->>Agent: Wants to take ownership
-    Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
+    Agent->>Service: POST /agent/identity/claim<br/>{ type: login_hint, claim_token, login_hint }
     Service-->>Agent: 200 OK (claim_attempt: user_code + verification_uri)
     Agent-->>User: Surface user_code + verification_uri
     User->>Service: GET verification_uri (signs in, lands on /claim)
@@ -163,5 +163,44 @@ sequenceDiagram
         Service-->>Agent: 200 OK (fresh claim_attempt: new user_code + verification_uri)
         Agent-->>User: Surface new user_code + verification_uri
       end
+    end
+```
+
+### Anonymous Registration Claimed via ID-JAG
+
+If the agent started anonymous and later acquired an ID-JAG (e.g., the user signed in through the agent's provider mid-run), the agent can claim the pending registration by presenting the ID-JAG at `/agent/identity/claim` with `type: identity_assertion`. Two branches:
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Agent
+    participant Provider as Agent Provider
+    participant Service
+
+    Agent->>Service: POST /agent/identity<br/>{ type: anonymous }
+    Service-->>Agent: 200 OK (identity_assertion v1, claim_token)
+
+    Note over Agent: Agent operates pre-claim<br/>(may exchange v1 for a pre-claim access_token)
+
+    User-->>Agent: Signs in at provider
+    Agent->>Provider: Request audience-specific ID-JAG
+    Provider-->>Agent: 200 OK (ID-JAG)
+
+    Agent->>Service: POST /agent/identity/claim<br/>{ type: identity_assertion, claim_token, assertion: ID-JAG }
+    Service->>Service: Verify ID-JAG + auth_time + matcher
+
+    alt Clean match (no email conflict, or existing (iss, sub) delegation)
+        Service-->>Agent: 200 OK (status: claimed, identity_assertion v2)
+        Note over Agent: Pre-claim access_token revoked.<br/>Agent exchanges v2 at /oauth2/token<br/>via jwt-bearer for a fresh credential.
+    else Step-up required (ID-JAG email matches an existing different user, no delegation)
+        Service-->>Agent: 200 OK (claim_attempt: user_code + verification_uri)
+        Agent-->>User: Surface user_code + verification_uri
+        User->>Service: GET verification_uri (signs in, lands on /claim)
+        User->>Service: POST /agent/identity/claim/complete<br/>{ claim_attempt_token, user_code }
+        Note over Service: Completion binds the anonymous reg<br/>to the signed-in user AND records<br/>the (iss, sub) delegation.
+        loop until claimed
+          Agent->>Service: POST /oauth2/token<br/>grant_type=claim&claim_token=...
+          Service-->>Agent: 200 OK (access_token + v2 identity_assertion) | authorization_pending
+        end
     end
 ```

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ sequenceDiagram
 
 ### Anonymous Registration Claimed via ID-JAG
 
-If the agent started anonymous and later acquired an ID-JAG (e.g., the user signed in through the agent's provider mid-run), the agent can claim the pending registration by presenting the ID-JAG at `/agent/identity/claim` with `type: identity_assertion`. Two branches:
+If the agent started anonymous, the user wants to claim the registration, and the agent can obtain an ID-JAG, it can bind the registration to that identity by presenting the ID-JAG at `/agent/identity/claim` with `type: identity_assertion`. Two branches:
 
 ```mermaid
 sequenceDiagram
@@ -189,10 +189,10 @@ sequenceDiagram
     Agent->>Service: POST /agent/identity/claim<br/>{ type: identity_assertion, claim_token, assertion: ID-JAG }
     Service->>Service: Verify ID-JAG + auth_time + matcher
 
-    alt Clean match (no email conflict, or existing (iss, sub) delegation)
+    alt No confirmation needed (no email conflict, or existing (iss, sub) delegation)
         Service-->>Agent: 200 OK (status: claimed, identity_assertion v2)
         Note over Agent: Pre-claim access_token revoked.<br/>Agent exchanges v2 at /oauth2/token<br/>via jwt-bearer for a fresh credential.
-    else Step-up required (ID-JAG email matches an existing different user, no delegation)
+    else Confirmation required (ID-JAG email matches an existing different account, no delegation)
         Service-->>Agent: 200 OK (claim_attempt: user_code + verification_uri)
         Agent-->>User: Surface user_code + verification_uri
         User->>Service: GET verification_uri (signs in, lands on /claim)

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -526,7 +526,7 @@ This is a service-owned UX surface — agents never see it.
 
 #### Claim via ID-JAG
 
-If the agent started anonymous and later acquired an ID-JAG for the user (e.g., the user signed in through the agent's provider mid-run), it can claim the pending registration atomically without dragging the user through the user_code ceremony. Same `/agent/identity/claim` endpoint, different `type`:
+If the agent started anonymous, the user wants to claim the registration, and the agent can obtain an ID-JAG for them, it can bind the registration atomically instead of taking the user through the user_code ceremony. Same `/agent/identity/claim` endpoint, different `type`:
 
 ```json
 {

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -554,7 +554,7 @@ Implementation:
      ```
 
      The agent exchanges the v2 assertion at `/oauth2/token` (jwt-bearer) for a post-claim access_token. Same shape as the user_code ceremony's terminal state — the only difference is no polling.
-   - **Step-up required** (`matcher.kind === "step_up_required"` — ID-JAG's verified email matches an existing different user, no `(iss, sub)` delegation): mint a fresh `claim_attempt` on the anonymous registration with the matched email and the `id_jag = { iss, sub, aud }` triple, and return **200 with the ceremony block** — the same shape `/agent/identity/claim` returns for the email-shape body. The agent surfaces `user_code` + `verification_uri` to the user; the user confirms at `/claim`, which binds the anonymous registration to the user AND records the `(iss, sub)` delegation in one shot. The agent then polls `/oauth2/token` (claim grant) for the post-claim access_token, same as the email-shape flow.
+   - **Step-up required** (`matcher.kind === "step_up_required"` — ID-JAG's verified email matches an existing different user, no `(iss, sub)` delegation): mint a fresh `claim_attempt` on the anonymous registration with the matched email and the `id_jag = { iss, sub, aud }` triple, and return **200 with the `claim_attempt` block** — the same shape `/agent/identity/claim` returns for the email-shape body. The agent surfaces `user_code` + `verification_uri` to the user; the user confirms at `/claim`, which binds the anonymous registration to the user AND records the `(iss, sub)` delegation in one shot. The agent then polls `/oauth2/token` (claim grant) for the post-claim access_token, same as the email-shape flow.
 
      ```json
      {

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -540,19 +540,35 @@ Implementation:
 
 1. Hash the `claim_token` and look up the registration. Reject if not found, expired, or already claimed; reject if `kind !== "anonymous"` with `claimed_or_in_flight`.
 2. Verify the ID-JAG the same way `/agent/identity` does — signature, audience, replay, `auth_time` freshness. `auth_time_*` errors become `401 login_required` so the agent knows to refresh upstream (same as the `/agent/identity` path).
-3. Run the matcher. If `kind === "step_up_required"` (ID-JAG matches an existing user, no `(iss, sub)` delegation yet), refuse with `401 interaction_required` pointing to `/agent/identity` — the user has to walk the normal step-up ceremony there to confirm linking the provider identity, after which a retry here clean-matches.
-4. On clean-match: bind the anonymous registration to the resolved user (`user_id`, `claimed_at`), record the ID-JAG triple as `id_jag = { iss, sub, aud }`, call `upsertDelegation`, revoke pre-claim access_tokens (same as user_code completion), and return a v2 `identity_assertion`:
+3. Run the matcher. Two terminal shapes from here:
+   - **Clean match** (no email conflict, or the existing `(iss, sub)` delegation matches): bind the anonymous registration to the resolved user (`user_id`, `claimed_at`), record the ID-JAG triple as `id_jag = { iss, sub, aud }`, call `upsertDelegation`, revoke pre-claim access_tokens (same as user_code completion), and return a v2 `identity_assertion`:
 
-```json
-{
-  "registration_id": "reg_...",
-  "status": "claimed",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z"
-}
-```
+     ```json
+     {
+       "registration_id": "reg_...",
+       "status": "claimed",
+       "identity_assertion": "<service-signed JWT>",
+       "assertion_expires": "2026-05-04T13:00:00.000Z"
+     }
+     ```
 
-The agent exchanges the v2 assertion at `/oauth2/token` (jwt-bearer) for a post-claim access_token. Same shape as the user_code ceremony's terminal state — the only difference is no polling.
+     The agent exchanges the v2 assertion at `/oauth2/token` (jwt-bearer) for a post-claim access_token. Same shape as the user_code ceremony's terminal state — the only difference is no polling.
+   - **Step-up required** (`matcher.kind === "step_up_required"` — ID-JAG's verified email matches an existing different user, no `(iss, sub)` delegation): mint a fresh `claim_attempt` on the anonymous registration with the matched email and the `id_jag = { iss, sub, aud }` triple, and return **200 with the ceremony block** — the same shape `/agent/identity/claim` returns for the email-shape body. The agent surfaces `user_code` + `verification_uri` to the user; the user confirms at `/claim`, which binds the anonymous registration to the user AND records the `(iss, sub)` delegation in one shot. The agent then polls `/oauth2/token` (claim grant) for the post-claim access_token, same as the email-shape flow.
+
+     ```json
+     {
+       "registration_id": "reg_...",
+       "claim_attempt_id": "cla_...",
+       "status": "initiated",
+       "expires_at": "...",
+       "claim_attempt": {
+         "user_code": "123456",
+         "verification_uri": "https://auth.service.example.com/claim?claim_attempt_token=...",
+         "expires_in": 600,
+         "interval": 5
+       }
+     }
+     ```
 
 **Why anonymous-only.** Email-verification registrations have already asserted an email and started a ceremony for that email. Replacing that with a different ID-JAG identity is ambiguous (which identity wins?) and not worth the complexity — agents that started email-verification but later got an ID-JAG can just re-register at `/agent/identity` with the ID-JAG directly.
 

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -473,16 +473,22 @@ The `verification_uri` routes through `/login` first so the user authenticates b
 
 Anonymous-only. Verified-email registrations skip this — their `claim` block is bundled into the `/agent/identity` registration response.
 
-Request:
+Two shapes, discriminated on `type`:
+
+- `type: "login_hint"` — start a user_code ceremony (default path; covered below).
+- `type: "identity_assertion"` — agent acquired an ID-JAG and wants to skip the ceremony; see [Claim via ID-JAG](#claim-via-id-jag) below.
+
+login_hint shape:
 
 ```json
 {
+  "type": "login_hint",
   "claim_token": "clm_abc123...",
-  "email": "user@example.com"
+  "login_hint": "user@example.com"
 }
 ```
 
-The `email` binds the registration to the human the agent is acting for. Only that signed-in user can complete the ceremony — without this binding, a third party who intercepts the `user_code` could claim the agent on their own account.
+The `login_hint` binds the registration to the human the agent is acting for. Only that signed-in user can complete the ceremony — without this binding, a third party who intercepts the `user_code` could claim the agent on their own account.
 
 Response (200):
 
@@ -517,6 +523,38 @@ The user opens `verification_uri`, signs in to the service, and lands on a page 
 4. On the form post, the service verifies the `user_code` against the registration's stored hash and marks the claim complete. Same-account check applies again on submit.
 
 This is a service-owned UX surface — agents never see it.
+
+#### Claim via ID-JAG
+
+If the agent started anonymous and later acquired an ID-JAG for the user (e.g., the user signed in through the agent's provider mid-run), it can claim the pending registration atomically without dragging the user through the user_code ceremony. Same `/agent/identity/claim` endpoint, different `type`:
+
+```json
+{
+  "type": "identity_assertion",
+  "claim_token": "clm_abc123...",
+  "assertion": "<ID-JAG JWT>"
+}
+```
+
+Implementation:
+
+1. Hash the `claim_token` and look up the registration. Reject if not found, expired, or already claimed; reject if `kind !== "anonymous"` with `claimed_or_in_flight`.
+2. Verify the ID-JAG the same way `/agent/identity` does — signature, audience, replay, `auth_time` freshness. `auth_time_*` errors become `401 login_required` so the agent knows to refresh upstream (same as the `/agent/identity` path).
+3. Run the matcher. If `kind === "step_up_required"` (ID-JAG matches an existing user, no `(iss, sub)` delegation yet), refuse with `401 interaction_required` pointing to `/agent/identity` — the user has to walk the normal step-up ceremony there to confirm linking the provider identity, after which a retry here clean-matches.
+4. On clean-match: bind the anonymous registration to the resolved user (`user_id`, `claimed_at`), record the ID-JAG triple as `id_jag = { iss, sub, aud }`, call `upsertDelegation`, revoke pre-claim access_tokens (same as user_code completion), and return a v2 `identity_assertion`:
+
+```json
+{
+  "registration_id": "reg_...",
+  "status": "claimed",
+  "identity_assertion": "<service-signed JWT>",
+  "assertion_expires": "2026-05-04T13:00:00.000Z"
+}
+```
+
+The agent exchanges the v2 assertion at `/oauth2/token` (jwt-bearer) for a post-claim access_token. Same shape as the user_code ceremony's terminal state — the only difference is no polling.
+
+**Why anonymous-only.** Email-verification registrations have already asserted an email and started a ceremony for that email. Replacing that with a different ID-JAG identity is ambiguous (which identity wins?) and not worth the complexity — agents that started email-verification but later got an ID-JAG can just re-register at `/agent/identity` with the ID-JAG directly.
 
 #### POST /oauth2/token (claim grant) — Agent poll
 

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -546,6 +546,7 @@ Implementation:
      ```json
      {
        "registration_id": "reg_...",
+       "registration_type": "identity_assertion",
        "status": "claimed",
        "identity_assertion": "<service-signed JWT>",
        "assertion_expires": "2026-05-04T13:00:00.000Z"
@@ -558,6 +559,7 @@ Implementation:
      ```json
      {
        "registration_id": "reg_...",
+       "registration_type": "identity_assertion",
        "claim_attempt_id": "cla_...",
        "status": "initiated",
        "expires_at": "...",

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -526,7 +526,7 @@ This is a service-owned UX surface — agents never see it.
 
 #### Claim via ID-JAG
 
-If the agent started anonymous, the user wants to claim the registration, and the agent can obtain an ID-JAG for them, it can bind the registration atomically instead of taking the user through the user_code ceremony. Same `/agent/identity/claim` endpoint, different `type`:
+If the agent started anonymous, the user wants to claim the registration, and the agent can obtain an ID-JAG for them, it can finish the claim in one shot instead of running the user through the user_code ceremony. Same `/agent/identity/claim` endpoint, different `type`:
 
 ```json
 {

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -336,9 +336,9 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
 });
 
 /*
- * Verifies the ID-JAG, then either binds the registration atomically
- * (clean match) or kicks off a user_code ceremony for the user to
- * confirm (step-up). Response shapes are documented in AUTH.md.
+ * Verifies the ID-JAG, then either completes the claim right away (when
+ * the ID-JAG is enough on its own) or starts a user_code ceremony for
+ * the user to confirm (when it isn't). Response shapes are in AUTH.md.
  */
 async function handleAnonymousClaimViaIdJag(
   registration: Registration,

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -297,6 +297,20 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     return;
   }
   if (parsed.value.type === "identity_assertion") {
+    /*
+     * The atomic ID-JAG claim path is anonymous-only. Email-verification
+     * registrations are already bound to a specific email and need that
+     * user to confirm; id_jag step-up registrations are already mid-
+     * ceremony and refresh via the email-shape body.
+     */
+    if (registration.kind !== "anonymous") {
+      res.status(409).json({
+        error: "claimed_or_in_flight",
+        message:
+          "ID-JAG claim is only supported for anonymous registrations. Use the email-shape body to refresh the ceremony.",
+      });
+      return;
+    }
     return handleAnonymousClaimViaIdJag(
       registration,
       parsed.value.assertion,

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -386,6 +386,27 @@ async function handleAnonymousClaimViaIdJag(
   const { claims } = verified;
   const match = matchOrProvision(claims);
 
+  /*
+   * Same email-immutability protection as the email-shape /claim path:
+   * if the registration already has a bound email (from a prior /claim
+   * call), the user this ID-JAG resolves to must have that email.
+   * Otherwise an agent could redirect the ceremony to a different user
+   * by swapping in an ID-JAG for someone else.
+   */
+  const boundEmail = registration.claim?.email;
+  const incomingEmail =
+    match.kind === "step_up_required"
+      ? match.matched_user.email
+      : match.user.email;
+  if (boundEmail && boundEmail.toLowerCase() !== incomingEmail.toLowerCase()) {
+    res.status(400).json({
+      error: "email_mismatch",
+      message:
+        "The ID-JAG resolves to a different user than the registration's bound email.",
+    });
+    return;
+  }
+
   if (match.kind === "step_up_required") {
     /*
      * The ID-JAG matched an existing user by verified email. The ID-JAG
@@ -430,7 +451,8 @@ async function handleAnonymousClaimViaIdJag(
      * surface store-level errors with the right HTTP shape if reached.
      */
     const status =
-      result.error === "previously_claimed"
+      result.error === "previously_claimed" ||
+      result.error === "ceremony_in_flight"
         ? 409
         : result.error === "claim_expired"
           ? 410

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -296,6 +296,14 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     });
     return;
   }
+  if (parsed.value.type === "identity_assertion") {
+    return handleAnonymousClaimViaIdJag(
+      registration,
+      parsed.value.assertion,
+      res,
+    );
+  }
+
   /*
    * Mint a fresh ceremony (new claim_attempt_token + new user_code). The
    * login_hint is per-attempt — a re-initiation may supply a corrected
@@ -341,13 +349,16 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
 
 /**
  * Anonymous-claim-via-ID-JAG: the agent skipped the user_code ceremony
- * because it already has an ID-JAG. Verify, match, bind atomically, return
- * a v2 identity_assertion the agent exchanges at /oauth2/token.
+ * because it already has an ID-JAG. Two terminal shapes:
  *
- * If the matcher would normally trigger step-up (ID-JAG's email matches an
- * existing user, no (iss, sub) delegation yet), refuse — the agent has to
- * walk normal step-up at /agent/identity first. After that completes, the
- * delegation exists; a retry here clean-matches.
+ *   - Clean match → bind atomically, return v2 identity_assertion (200,
+ *     status: "claimed").
+ *   - Step-up required (ID-JAG email matches a different existing user,
+ *     no (iss, sub) delegation yet) → mint a user_code ceremony bound to
+ *     the matched user AND the ID-JAG triple, return the same ceremony
+ *     block as the email-shape claim (200, status: "initiated"). The
+ *     agent surfaces the code; the user confirms at /claim; completeClaim
+ *     binds both the user and the (iss, sub) delegation.
  */
 async function handleAnonymousClaimViaIdJag(
   registration: Registration,

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -406,6 +406,7 @@ async function handleAnonymousClaimViaIdJag(
     );
     res.json({
       registration_id: registration.id,
+      registration_type: "identity_assertion",
       claim_attempt_id: attempt.id,
       status: "initiated",
       expires_at: attempt.view_expires_at.toISOString(),
@@ -449,6 +450,7 @@ async function handleAnonymousClaimViaIdJag(
   );
   res.json({
     registration_id: result.registration.id,
+    registration_type: "identity_assertion",
     status: "claimed",
     identity_assertion: jwt,
     assertion_expires: expiresAt.toISOString(),

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -336,9 +336,9 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
 });
 
 /*
- * Verifies the ID-JAG, then either completes the claim right away (when
- * the ID-JAG is enough on its own) or starts a user_code ceremony for
- * the user to confirm (when it isn't). Response shapes are in AUTH.md.
+ * Verifies the ID-JAG and finishes the claim straight away if it can.
+ * If the ID-JAG isn't enough on its own, falls back to a user_code
+ * ceremony so the user can confirm. Response shapes are in AUTH.md.
  */
 async function handleAnonymousClaimViaIdJag(
   registration: Registration,

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -254,19 +254,6 @@ async function handleServiceAuth(
   });
 }
 
-/*
- * Initiates or re-mints a claim. Dispatched on body `type`:
- *
- *   - { type: "login_hint", claim_token, login_hint } → start or refresh
- *     a user_code ceremony. Anonymous registrations get first-initiation
- *     here (login_hint binds the registration); service_auth registrations
- *     get refresh-only (the initial ceremony was minted at /agent/identity).
- *   - { type: "identity_assertion", claim_token, assertion } → claim
- *     an anonymous registration atomically using an ID-JAG (no
- *     user_code ceremony needed). Step-up returns a ceremony block
- *     directly when the ID-JAG email matches a different existing
- *     account.
- */
 agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   const parsed = parseBody(claimBody, req.body);
   if (!parsed.ok) {
@@ -297,12 +284,7 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     return;
   }
   if (parsed.value.type === "identity_assertion") {
-    /*
-     * The atomic ID-JAG claim path is anonymous-only. service_auth
-     * registrations are already bound to a specific login_hint and need
-     * that user to confirm; id_jag step-up registrations are already mid-
-     * ceremony and refresh via the login_hint-shape body.
-     */
+    /* Only anonymous registrations claim atomically via ID-JAG. */
     if (registration.kind !== "anonymous") {
       res.status(409).json({
         error: "claimed_or_in_flight",
@@ -353,18 +335,10 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   });
 });
 
-/**
- * Anonymous-claim-via-ID-JAG: the agent skipped the user_code ceremony
- * because it already has an ID-JAG. Two terminal shapes:
- *
- *   - Clean match → bind atomically, return v2 identity_assertion (200,
- *     status: "claimed").
- *   - Step-up required (ID-JAG email matches a different existing user,
- *     no (iss, sub) delegation yet) → mint a user_code ceremony bound to
- *     the matched user AND the ID-JAG triple, return the same ceremony
- *     block as the email-shape claim (200, status: "initiated"). The
- *     agent surfaces the code; the user confirms at /claim; completeClaim
- *     binds both the user and the (iss, sub) delegation.
+/*
+ * Verifies the ID-JAG, then either binds the registration atomically
+ * (clean match) or kicks off a user_code ceremony for the user to
+ * confirm (step-up). Response shapes are documented in AUTH.md.
  */
 async function handleAnonymousClaimViaIdJag(
   registration: Registration,
@@ -380,12 +354,9 @@ async function handleAnonymousClaimViaIdJag(
 
   if (match.kind === "step_up_required") {
     /*
-     * The ID-JAG matched an existing user by verified email. The ID-JAG
-     * alone isn't enough — we need the user to confirm linking this
-     * provider identity to their account. Initiate the same user_code
-     * ceremony as the login_hint-shape claim, but bind the ID-JAG triple onto
-     * the anonymous registration so completeClaim upserts the (iss, sub)
-     * delegation alongside the user binding.
+     * Bind the ID-JAG triple onto the registration alongside the
+     * ceremony so completeClaim upserts the (iss, sub) delegation when
+     * the user confirms.
      */
     const fresh = recordClaimAttempt(
       registration,

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -298,16 +298,16 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   }
   if (parsed.value.type === "identity_assertion") {
     /*
-     * The atomic ID-JAG claim path is anonymous-only. Email-verification
-     * registrations are already bound to a specific email and need that
-     * user to confirm; id_jag step-up registrations are already mid-
-     * ceremony and refresh via the email-shape body.
+     * The atomic ID-JAG claim path is anonymous-only. service_auth
+     * registrations are already bound to a specific login_hint and need
+     * that user to confirm; id_jag step-up registrations are already mid-
+     * ceremony and refresh via the login_hint-shape body.
      */
     if (registration.kind !== "anonymous") {
       res.status(409).json({
         error: "claimed_or_in_flight",
         message:
-          "ID-JAG claim is only supported for anonymous registrations. Use the email-shape body to refresh the ceremony.",
+          "ID-JAG claim is only supported for anonymous registrations. Use the login_hint-shape body to refresh the ceremony.",
       });
       return;
     }
@@ -324,14 +324,6 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
    * email; only the current attempt's view_token and user_code work, and
    * the /claim page surfaces the current attempt's hint as an advisory.
    */
-  if (parsed.value.type === "identity_assertion") {
-    return handleAnonymousClaimViaIdJag(
-      registration,
-      parsed.value.assertion,
-      res,
-    );
-  }
-
   const login_hint = classifyLoginHint(parsed.value.login_hint);
   if (!login_hint) {
     res.status(400).json({
@@ -385,27 +377,6 @@ async function handleAnonymousClaimViaIdJag(
   }
   const { claims } = verified;
   const match = matchOrProvision(claims);
-
-  /*
-   * Same email-immutability protection as the email-shape /claim path:
-   * if the registration already has a bound email (from a prior /claim
-   * call), the user this ID-JAG resolves to must have that email.
-   * Otherwise an agent could redirect the ceremony to a different user
-   * by swapping in an ID-JAG for someone else.
-   */
-  const boundEmail = registration.claim?.email;
-  const incomingEmail =
-    match.kind === "step_up_required"
-      ? match.matched_user.email
-      : match.user.email;
-  if (boundEmail && boundEmail.toLowerCase() !== incomingEmail.toLowerCase()) {
-    res.status(400).json({
-      error: "email_mismatch",
-      message:
-        "The ID-JAG resolves to a different user than the registration's bound email.",
-    });
-    return;
-  }
 
   if (match.kind === "step_up_required") {
     /*

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -5,6 +5,7 @@ import { agentAuthBody, claimBody, parseBody } from "../schemas.js";
 import {
   type Registration,
   classifyLoginHint,
+  completeAnonymousClaimViaIdJag,
   createAnonymousRegistration,
   createServiceAuthRegistration,
   findOrCreateIdJagRegistration,
@@ -254,11 +255,17 @@ async function handleServiceAuth(
 }
 
 /*
- * Initiates or re-mints a claim ceremony. Two registration kinds reach here:
- *   - anonymous: first initiation (binds the email) or refresh (after the
- *     user_code window closed before the user could complete).
- *   - service_auth: refresh only (the initial ceremony was minted at
- *     /agent/identity); the supplied email must match the registration.
+ * Initiates or re-mints a claim. Dispatched on body `type`:
+ *
+ *   - { type: "login_hint", claim_token, login_hint } → start or refresh
+ *     a user_code ceremony. Anonymous registrations get first-initiation
+ *     here (login_hint binds the registration); service_auth registrations
+ *     get refresh-only (the initial ceremony was minted at /agent/identity).
+ *   - { type: "identity_assertion", claim_token, assertion } → claim
+ *     an anonymous registration atomically using an ID-JAG (no
+ *     user_code ceremony needed). Step-up returns a ceremony block
+ *     directly when the ID-JAG email matches a different existing
+ *     account.
  */
 agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   const parsed = parseBody(claimBody, req.body);
@@ -295,14 +302,28 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
    * email; only the current attempt's view_token and user_code work, and
    * the /claim page surfaces the current attempt's hint as an advisory.
    */
-  const fresh = recordClaimAttempt(registration, {
-    kind: "email",
-    value: parsed.value.email,
-  });
+  if (parsed.value.type === "identity_assertion") {
+    return handleAnonymousClaimViaIdJag(
+      registration,
+      parsed.value.assertion,
+      res,
+    );
+  }
+
+  const login_hint = classifyLoginHint(parsed.value.login_hint);
+  if (!login_hint) {
+    res.status(400).json({
+      error: "invalid_login_hint",
+      message: "login_hint does not match a recognizable identifier shape.",
+    });
+    return;
+  }
+
+  const fresh = recordClaimAttempt(registration, login_hint);
   const attempt = registration.claim!.attempt!;
 
   console.log(
-    `[agent-auth] claim initiated for registration=${registration.id} to=${parsed.value.email}`,
+    `[agent-auth] claim initiated for registration=${registration.id} to=${parsed.value.login_hint}`,
   );
 
   res.json({
@@ -317,6 +338,97 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     }),
   });
 });
+
+/**
+ * Anonymous-claim-via-ID-JAG: the agent skipped the user_code ceremony
+ * because it already has an ID-JAG. Verify, match, bind atomically, return
+ * a v2 identity_assertion the agent exchanges at /oauth2/token.
+ *
+ * If the matcher would normally trigger step-up (ID-JAG's email matches an
+ * existing user, no (iss, sub) delegation yet), refuse — the agent has to
+ * walk normal step-up at /agent/identity first. After that completes, the
+ * delegation exists; a retry here clean-matches.
+ */
+async function handleAnonymousClaimViaIdJag(
+  registration: Registration,
+  assertion: string,
+  res: express.Response,
+): Promise<void> {
+  const verified = await verifyIdJag(assertion);
+  if (!verified.ok) {
+    return handleIdJagVerifyError(verified.error, res);
+  }
+  const { claims } = verified;
+  const match = matchOrProvision(claims);
+
+  if (match.kind === "step_up_required") {
+    /*
+     * The ID-JAG matched an existing user by verified email. The ID-JAG
+     * alone isn't enough — we need the user to confirm linking this
+     * provider identity to their account. Initiate the same user_code
+     * ceremony as the login_hint-shape claim, but bind the ID-JAG triple onto
+     * the anonymous registration so completeClaim upserts the (iss, sub)
+     * delegation alongside the user binding.
+     */
+    const fresh = recordClaimAttempt(
+      registration,
+      { kind: "email", value: match.matched_user.email },
+      { iss: claims.iss, sub: claims.sub, aud: claims.aud },
+    );
+    const attempt = registration.claim!.attempt!;
+    console.log(
+      `[agent-auth] anon claim via ID-JAG requires step-up: registration=${registration.id} iss=${claims.iss} sub=${claims.sub}`,
+    );
+    res.json({
+      registration_id: registration.id,
+      claim_attempt_id: attempt.id,
+      status: "initiated",
+      expires_at: attempt.view_expires_at.toISOString(),
+      claim_attempt: buildCeremonyBlock({
+        claimViewTokenPlaintext: fresh.claimViewTokenPlaintext,
+        userCode: fresh.userCode,
+        userCodeExpiresAt: fresh.userCodeExpiresAt,
+      }),
+    });
+    return;
+  }
+
+  const result = completeAnonymousClaimViaIdJag(
+    registration,
+    { iss: claims.iss, sub: claims.sub, aud: claims.aud },
+    match.user,
+  );
+  if (!result.ok) {
+    /*
+     * Defensive: the route-level checks above already rule these out, but
+     * surface store-level errors with the right HTTP shape if reached.
+     */
+    const status =
+      result.error === "previously_claimed"
+        ? 409
+        : result.error === "claim_expired"
+          ? 410
+          : 400;
+    res.status(status).json({ error: result.error });
+    return;
+  }
+
+  const { jwt, expiresAt } = await signServiceIdJag({
+    registration: result.registration,
+    email: claims.email,
+    emailVerified: claims.email_verified,
+    amr: claims.amr,
+  });
+  console.log(
+    `[agent-auth] anonymous registration=${result.registration.id} claimed via ID-JAG for user=${result.user.id} iss=${claims.iss} sub=${claims.sub}`,
+  );
+  res.json({
+    registration_id: result.registration.id,
+    status: "claimed",
+    identity_assertion: jwt,
+    assertion_expires: expiresAt.toISOString(),
+  });
+}
 
 /*
  * Polling moved to /oauth2/token with grant_type=urn:workos:agent-auth:

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -341,6 +341,7 @@ function updateAnonExchangePreview() {
 }
 function updateAnonClaimPreview() {
   const body = {
+    type: "user_code",
     claim_token: abbrev(state.anon_claim_token),
     email: document.getElementById("anon-claim-email").value,
   };
@@ -472,8 +473,9 @@ async function anonCallPre() {
 
 async function anonClaim() {
   const body = {
+    type: "login_hint",
     claim_token: state.anon_claim_token,
-    email: document.getElementById("anon-claim-email").value,
+    login_hint: document.getElementById("anon-claim-email").value,
   };
   const r = await jsonFetch("/agent/identity/claim", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("anon-claim-out").innerHTML = resBlock(r.status, null, r.body, r.ok);

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -341,7 +341,7 @@ function updateAnonExchangePreview() {
 }
 function updateAnonClaimPreview() {
   const body = {
-    type: "user_code",
+    type: "email",
     claim_token: abbrev(state.anon_claim_token),
     email: document.getElementById("anon-claim-email").value,
   };

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -23,10 +23,31 @@ export const agentAuthBody = z.union([
   anonymousBody,
 ]);
 
-export const claimBody = z.object({
+/**
+ * Two shapes for POST /agent/identity/claim, discriminated on `type`:
+ *  - `login_hint`: agent provides a login_hint for the user who's
+ *    claiming. Starts a user_code ceremony (the user signs in at the
+ *    service and types a code the agent surfaces).
+ *  - `identity_assertion`: agent provides an ID-JAG. Completes the claim
+ *    atomically — useful when the agent acquired an ID-JAG after starting
+ *    anonymous and wants to short-circuit the browser ceremony.
+ */
+const loginHintClaimBody = z.object({
+  type: z.literal("login_hint"),
   claim_token: z.string().min(1),
-  email: z.email(),
+  login_hint: z.string().min(1),
 });
+
+const idJagClaimBody = z.object({
+  type: z.literal("identity_assertion"),
+  claim_token: z.string().min(1),
+  assertion: z.string().min(1),
+});
+
+export const claimBody = z.discriminatedUnion("type", [
+  loginHintClaimBody,
+  idJagClaimBody,
+]);
 
 /** Mock IdP sign-in form. */
 export const loginFormBody = z.object({

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -23,15 +23,7 @@ export const agentAuthBody = z.union([
   anonymousBody,
 ]);
 
-/**
- * Two shapes for POST /agent/identity/claim, discriminated on `type`:
- *  - `login_hint`: agent provides a login_hint for the user who's
- *    claiming. Starts a user_code ceremony (the user signs in at the
- *    service and types a code the agent surfaces).
- *  - `identity_assertion`: agent provides an ID-JAG. Completes the claim
- *    atomically — useful when the agent acquired an ID-JAG after starting
- *    anonymous and wants to short-circuit the browser ceremony.
- */
+/* POST /agent/identity/claim — discriminated on `type`. */
 const loginHintClaimBody = z.object({
   type: z.literal("login_hint"),
   claim_token: z.string().min(1),

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -663,7 +663,11 @@ export type IdJagClaimResult =
   | { ok: true; registration: Registration; user: User }
   | {
       ok: false;
-      error: "previously_claimed" | "claim_expired" | "wrong_kind";
+      error:
+        | "previously_claimed"
+        | "claim_expired"
+        | "wrong_kind"
+        | "ceremony_in_flight";
     };
 
 /**
@@ -691,6 +695,17 @@ export function completeAnonymousClaimViaIdJag(
   }
   if (registration.status === "expired") {
     return { ok: false, error: "claim_expired" };
+  }
+  /*
+   * Defense-in-depth: refuse to atomically bind when a user_code ceremony
+   * is already in flight for this registration. The route-layer email-
+   * immutability check already prevents the typical hijack scenario by
+   * ensuring the ID-JAG resolves to the bound user, but this gate stops
+   * any code path that bypasses the route from silently overwriting an
+   * in-flight ceremony's state.
+   */
+  if (registration.status === "pending_claim") {
+    return { ok: false, error: "ceremony_in_flight" };
   }
 
   registration.user_id = user.id;

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -527,6 +527,12 @@ export function findRegistrationByClaimViewHash(
 export function recordClaimAttempt(
   registration: Registration,
   login_hint: LoginHint,
+  /**
+   * Optional ID-JAG triple to bind on completion. Set when the ceremony
+   * was triggered by an ID-JAG step-up at /claim — completeClaim then
+   * upserts the (iss, sub) delegation alongside the user binding.
+   */
+  idJag?: { iss: string; sub: string; aud: string },
 ): {
   claimViewTokenPlaintext: string;
   userCode: string;
@@ -549,6 +555,7 @@ export function recordClaimAttempt(
     user_code_expires_at: code.expiresAt,
     login_hint,
   };
+  if (idJag) registration.id_jag = idJag;
   return {
     claimViewTokenPlaintext: plaintext,
     userCode: code.plaintext,
@@ -634,10 +641,13 @@ export function completeClaim(
     }
   }
 
-  if (registration.kind === "id_jag" && registration.id_jag) {
+  if (registration.id_jag) {
     /*
-     * Step-up complete: bind the (iss, sub) → user delegation so future
-     * ID-JAGs from this provider for this sub take the clean-match path.
+     * If an ID-JAG triple is recorded (set on id_jag-kind step-up
+     * registrations, or anonymous registrations whose ceremony was
+     * initiated by an ID-JAG step-up at /claim), bind the (iss, sub) →
+     * user delegation so future ID-JAGs from this provider for this sub
+     * take the clean-match path.
      */
     upsertDelegation(
       registration.id_jag.iss,
@@ -647,4 +657,53 @@ export function completeClaim(
   }
 
   return { ok: true, registration, user: signedInUser };
+}
+
+export type IdJagClaimResult =
+  | { ok: true; registration: Registration; user: User }
+  | {
+      ok: false;
+      error: "previously_claimed" | "claim_expired" | "wrong_kind";
+    };
+
+/**
+ * Complete an anonymous claim atomically by binding it to a verified ID-JAG
+ * instead of running the user_code ceremony. The agent presented an ID-JAG
+ * (verified upstream); we record the (iss, sub, aud) on the registration
+ * and bind the delegation. Pre-claim access_tokens are revoked, same as
+ * the user_code path. Returns the updated registration so the caller can
+ * mint a v2 identity_assertion.
+ *
+ * Restricted to anonymous registrations — email-verification regs are
+ * already mid-ceremony with their own asserted email; mixing in a
+ * different ID-JAG identity there isn't meaningful.
+ */
+export function completeAnonymousClaimViaIdJag(
+  registration: Registration,
+  idJag: { iss: string; sub: string; aud: string },
+  user: User,
+): IdJagClaimResult {
+  if (registration.kind !== "anonymous") {
+    return { ok: false, error: "wrong_kind" };
+  }
+  if (registration.status === "claimed") {
+    return { ok: false, error: "previously_claimed" };
+  }
+  if (registration.status === "expired") {
+    return { ok: false, error: "claim_expired" };
+  }
+
+  registration.user_id = user.id;
+  registration.claimed_at = new Date();
+  registration.id_jag = idJag;
+  upsertDelegation(idJag.iss, idJag.sub, user.id);
+
+  /* Revoke pre-claim access_tokens — same as the user_code path. */
+  for (const cred of credentials.values()) {
+    if (cred.registration_id === registration.id && !cred.revoked) {
+      cred.revoked = true;
+    }
+  }
+
+  return { ok: true, registration, user };
 }

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -527,11 +527,7 @@ export function findRegistrationByClaimViewHash(
 export function recordClaimAttempt(
   registration: Registration,
   login_hint: LoginHint,
-  /**
-   * Optional ID-JAG triple to bind on completion. Set when the ceremony
-   * was triggered by an ID-JAG step-up at /claim — completeClaim then
-   * upserts the (iss, sub) delegation alongside the user binding.
-   */
+  /* When set, completeClaim upserts the (iss, sub) → user delegation. */
   idJag?: { iss: string; sub: string; aud: string },
 ): {
   claimViewTokenPlaintext: string;
@@ -642,13 +638,8 @@ export function completeClaim(
   }
 
   if (registration.id_jag) {
-    /*
-     * If an ID-JAG triple is recorded (set on id_jag-kind step-up
-     * registrations, or anonymous registrations whose ceremony was
-     * initiated by an ID-JAG step-up at /claim), bind the (iss, sub) →
-     * user delegation so future ID-JAGs from this provider for this sub
-     * take the clean-match path.
-     */
+    /* Bind the (iss, sub) → user delegation so future ID-JAGs from this
+     * provider for this sub take the clean-match path. */
     upsertDelegation(
       registration.id_jag.iss,
       registration.id_jag.sub,
@@ -670,17 +661,11 @@ export type IdJagClaimResult =
         | "ceremony_in_flight";
     };
 
-/**
- * Complete an anonymous claim atomically by binding it to a verified ID-JAG
- * instead of running the user_code ceremony. The agent presented an ID-JAG
- * (verified upstream); we record the (iss, sub, aud) on the registration
- * and bind the delegation. Pre-claim access_tokens are revoked, same as
- * the user_code path. Returns the updated registration so the caller can
- * mint a v2 identity_assertion.
- *
- * Restricted to anonymous registrations — email-verification regs are
- * already mid-ceremony with their own asserted email; mixing in a
- * different ID-JAG identity there isn't meaningful.
+/*
+ * Atomic counterpart to completeClaim's user_code path: bind the
+ * anonymous registration to the ID-JAG's user, record the (iss, sub, aud)
+ * triple as a delegation, revoke pre-claim access_tokens. The caller
+ * mints the v2 identity_assertion off the returned registration.
  */
 export function completeAnonymousClaimViaIdJag(
   registration: Registration,
@@ -696,14 +681,8 @@ export function completeAnonymousClaimViaIdJag(
   if (registration.status === "expired") {
     return { ok: false, error: "claim_expired" };
   }
-  /*
-   * Defense-in-depth: refuse to atomically bind when a user_code ceremony
-   * is already in flight for this registration. The route-layer email-
-   * immutability check already prevents the typical hijack scenario by
-   * ensuring the ID-JAG resolves to the bound user, but this gate stops
-   * any code path that bypasses the route from silently overwriting an
-   * in-flight ceremony's state.
-   */
+  /* Defense-in-depth: never atomically bind over an in-flight ceremony.
+   * The route's email-immutability gate is the primary check. */
   if (registration.status === "pending_claim") {
     return { ok: false, error: "ceremony_in_flight" };
   }

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -638,8 +638,9 @@ export function completeClaim(
   }
 
   if (registration.id_jag) {
-    /* Bind the (iss, sub) → user delegation so future ID-JAGs from this
-     * provider for this sub take the clean-match path. */
+    /* Record the (iss, sub) → user delegation. Future ID-JAGs from this
+     * provider for this sub will resolve to this user directly, with no
+     * ceremony required. */
     upsertDelegation(
       registration.id_jag.iss,
       registration.id_jag.sub,
@@ -662,10 +663,11 @@ export type IdJagClaimResult =
     };
 
 /*
- * Atomic counterpart to completeClaim's user_code path: bind the
- * anonymous registration to the ID-JAG's user, record the (iss, sub, aud)
- * triple as a delegation, revoke pre-claim access_tokens. The caller
- * mints the v2 identity_assertion off the returned registration.
+ * Finishes a claim in one step using an ID-JAG, instead of running the
+ * user_code ceremony. Binds the registration to the ID-JAG's user,
+ * records the (iss, sub, aud) as a delegation, revokes pre-claim
+ * access_tokens. Caller mints a fresh identity_assertion from the
+ * returned registration.
  */
 export function completeAnonymousClaimViaIdJag(
   registration: Registration,
@@ -681,8 +683,9 @@ export function completeAnonymousClaimViaIdJag(
   if (registration.status === "expired") {
     return { ok: false, error: "claim_expired" };
   }
-  /* Defense-in-depth: never atomically bind over an in-flight ceremony.
-   * The route's email-immutability gate is the primary check. */
+  /* A user_code ceremony is already in flight for this registration —
+   * the user may be on the /claim page right now. Let it finish (or
+   * time out) before completing via the ID-JAG path. */
   if (registration.status === "pending_claim") {
     return { ok: false, error: "ceremony_in_flight" };
   }

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -638,9 +638,9 @@ export function completeClaim(
   }
 
   if (registration.id_jag) {
-    /* Record the (iss, sub) → user delegation. Future ID-JAGs from this
-     * provider for this sub will resolve to this user directly, with no
-     * ceremony required. */
+    /* Remember the (iss, sub) → user mapping so the next ID-JAG from
+     * this provider for this sub goes straight through without a
+     * ceremony. */
     upsertDelegation(
       registration.id_jag.iss,
       registration.id_jag.sub,
@@ -663,11 +663,11 @@ export type IdJagClaimResult =
     };
 
 /*
- * Finishes a claim in one step using an ID-JAG, instead of running the
- * user_code ceremony. Binds the registration to the ID-JAG's user,
- * records the (iss, sub, aud) as a delegation, revokes pre-claim
- * access_tokens. Caller mints a fresh identity_assertion from the
- * returned registration.
+ * Closes out a claim in one shot using an ID-JAG, no user_code
+ * ceremony needed. Binds the registration to the ID-JAG's user,
+ * records the (iss, sub, aud) as a delegation, and revokes any
+ * pre-claim access_tokens. The caller mints a fresh identity_assertion
+ * off the returned registration.
  */
 export function completeAnonymousClaimViaIdJag(
   registration: Registration,
@@ -683,9 +683,9 @@ export function completeAnonymousClaimViaIdJag(
   if (registration.status === "expired") {
     return { ok: false, error: "claim_expired" };
   }
-  /* A user_code ceremony is already in flight for this registration —
-   * the user may be on the /claim page right now. Let it finish (or
-   * time out) before completing via the ID-JAG path. */
+  /* There's already a user_code ceremony in flight — the user might
+   * be looking at the /claim page right now. Let that finish (or time
+   * out) before the ID-JAG path takes over. */
   if (registration.status === "pending_claim") {
     return { ok: false, error: "ceremony_in_flight" };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-md",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "pnpm --filter shared build && concurrently --names agent-provider,agent-service --prefix-colors blue,magenta \"pnpm --filter agent-providers dev\" \"pnpm --filter agent-services dev\"",


### PR DESCRIPTION
- [ ] I have QA'd the changes

## Stack

1. #8
2. #9
3. #10
4. #11
5. **#12** ← you are here

## Summary

`POST /agent/identity/claim` gains a second body shape, discriminated on `type`:

```
{ "type": "email", "claim_token": "...", "email": "..." }                      → start user_code ceremony (existing)
{ "type": "identity_assertion", "claim_token": "...", "assertion": "<ID-JAG>" } → claim atomically via ID-JAG (new)
```

The flow this unlocks: an agent starts anonymous, does pre-claim work, later acquires an ID-JAG (user signed in at the agent's provider mid-run) and binds the existing anonymous registration to that user. Keeps `registration_id` and pre-claim continuity intact instead of throwing it away and re-registering.

## Verification chain

`/claim` with `type: identity_assertion` runs the **same** verification chain as `/agent/identity`. Failures route the same way:

| ID-JAG state | Response |
|---|---|
| Signature / audience / replay bad | 400 with the verifier error code |
| `auth_time` missing or stale | **401 `login_required`** with `WWW-Authenticate: AgentAuth error="login_required", max_age="…"` |
| Matcher: existing `(iss, sub)` delegation OR JIT (no email conflict) | **200 + v2 `identity_assertion`** — ID-JAG alone is enough; bound atomically |
| Matcher: `step_up_required` (ID-JAG's email matches an existing different user, no delegation yet) | **200 + `claim_attempt` ceremony block** — user must confirm at `/claim`. The ceremony binds the anonymous registration AND the `(iss, sub)` delegation in one shot. |

The step-up branch returns the ceremony block right here rather than redirecting to `/agent/identity` — `/claim` is already the user-mediated confirmation surface; there's no reason to bounce the agent across endpoints.

## Implementation

- `schemas.ts`: `claimBody` becomes a `z.discriminatedUnion("type", …)`.
- `store.ts`:
  - `recordAnonymousClaimAttempt` accepts an optional `idJag` triple. When set, the anonymous registration records `id_jag = { iss, sub, aud }` so `completeClaim` upserts the delegation alongside the user binding.
  - `completeAnonymousClaimViaIdJag` handles the atomic clean-match path (no ceremony): binds user + delegation, records `id_jag`, revokes pre-claim access_tokens.
  - `completeClaim` upserts delegation based on `registration.id_jag` presence (not kind), so both step-up-via-`/identity` and step-up-via-`/claim` paths bind delegations on completion.
- `agent-auth.ts` `/claim` handler dispatches on `parsed.value.type`. The new `handleAnonymousClaimViaIdJag` runs `verifyIdJag` → `matchOrProvision` → branches on `match.kind`.
- Demo: existing anon claim call now sends the `type` field.
- Docs: AUTH.md Step 4 gets a "4a-alt. Claim via ID-JAG" subsection; agent-services README documents both shapes; README.md gets a new sequence diagram showing the two branches.

## Smoke test

Step-up path (ceremony required):
1. Pre-seed `alice@example.com` at the service via email-verif
2. Anonymous register
3. `POST /claim` with `type: identity_assertion` + ID-JAG → **200 with `claim_attempt` (user_code 428947)** ✓
4. User completes ceremony at `/claim` → 200
5. Agent polls `/oauth2/token` with claim grant → **scope `api.read api.write`**, v2 assertion's `email: alice@example.com` ✓

Clean-match path (ID-JAG enough):
6. Fresh anonymous register
7. `POST /claim` with `type: identity_assertion` + ID-JAG (same `(iss, sub)`, delegation now exists from step 5) → **200 + immediate v2 `identity_assertion`**, no ceremony ✓

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
