### PR TITLE
Rename verified_email → service_auth, rework how the claim email is stored + managed

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -72,11 +72,10 @@ Response shape:
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion"],
+    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
     "identity_assertion": {
       "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag",
-        "verified_email"
+        "urn:ietf:params:oauth:token-type:id-jag"
       ]
     },
     "events_supported": [
@@ -97,7 +96,7 @@ The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `toke
 - `agent_auth.claim_endpoint` — where you POST the claim invite for anonymous registrations (Step 4) and where the agent polls for ceremony completion at `/view`.
 - `agent_auth.events_endpoint` — where the provider POSTs a [Security Event Token (RFC 8417)](https://datatracker.ietf.org/doc/html/rfc8417) per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) push delivery to notify the service of upstream identity events. You don't call this; it tells you what to expect.
 - `agent_auth.identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
-- `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts (ID-JAG, verified email, etc.).
+- `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts under the `identity_assertion` shape (currently ID-JAG).
 - `agent_auth.events_supported` — event schemas this service can ingest (currently revocation). Informational; you don't act on these directly.
 
 ## Step 2 — Pick a method
@@ -105,18 +104,18 @@ The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `toke
 Use this decision tree:
 
 1. **You have a session tied to a user identity and can exchange it for an ID-JAG, audience-bound to this service** → [identity_assertion + id-jag](#identity_assertion--id-jag).
-2. **You have only the user's email** → [identity_assertion + email](#identity_assertion--email). Claim ceremony required.
+2. **You have only the user's email** → [service_auth](#service_auth). Claim ceremony required.
 3. **You have neither** → [anonymous](#anonymous). Claim ceremony optional; deferred until the user wants to take ownership.
 
-Before sending: cross-check your choice against the `agent_auth` block. If the matching `*_supported` array doesn't list your method, this service won't accept that registration shape — pick another or stop.
+For `identity_assertion`, cross-check that your assertion type is in `agent_auth.identity_assertion.assertion_types_supported` — trust setup isn't enumerable by trial, so a missing entry means stop. For `service_auth` and `anonymous`, `identity_types_supported` is informational — send the body and fall back on the `*_not_enabled` error if the service opted out.
 
 ## Step 3 — Register
 
-Before sending an `identity_assertion` (either variant), surface the service's `resource_name` and `resource_logo_uri` (from Step 1a) and the scope set you'll be acting under, and confirm with the user. This is the user's only consent gate before their identity is asserted to the service. Skip this for `anonymous` — there is no user identity to assert.
+Before sending an `identity_assertion` or `service_auth` body, surface the service's `resource_name` and `resource_logo_uri` (from Step 1a) and the scope set you'll be acting under, and confirm with the user. This is the user's only consent gate before their identity is asserted to the service. Skip this for `anonymous` — there is no user identity to assert.
 
 ### identity_assertion + id-jag
 
-Before minting the ID-JAG, confirm your provider is on this service's trust list (publishing format is service-specific — check the AS metadata or service docs). If it isn't, fall back to `identity_assertion + email` or `anonymous`.
+Before minting the ID-JAG, confirm your provider is on this service's trust list (publishing format is service-specific — check the AS metadata or service docs). If it isn't, fall back to `service_auth` or `anonymous`.
 
 Mint the assertion with:
 
@@ -178,7 +177,7 @@ WWW-Authenticate: AgentAuth error="interaction_required", error_description="…
 }
 ```
 
-Same `claim` block as email-verification — the user signs in to the service, sees a confirmation page that names your provider ("**Acme Provider** is asking to link this account so the agent it runs can act on your behalf"), and types the `user_code` to confirm. Surface `verification_uri` + `user_code` to the user (see [Step 4b](#4b-hand-off-to-the-user)) and poll the token endpoint (see [Step 4c](#4c-poll-for-completion)).
+Same `claim` block as the `service_auth` registration response — the user signs in to the service, sees a confirmation page that names your provider ("**Acme Provider** is asking to link this account so the agent it runs can act on your behalf"), and types the `user_code` to confirm. Surface `verification_uri` + `user_code` to the user (see [Step 4b](#4b-hand-off-to-the-user)) and poll the token endpoint (see [Step 4c](#4c-poll-for-completion)).
 
 After the user confirms, the next presentation of an ID-JAG for the same `(iss, sub, aud)` is accepted directly — no confirmation needed.
 
@@ -195,16 +194,15 @@ WWW-Authenticate: AgentAuth error="login_required", max_age="3600", error_descri
 }
 ```
 
-### identity_assertion + email
+### service_auth
 
 ```http
 POST /agent/identity
 Content-Type: application/json
 
 {
-  "type": "identity_assertion",
-  "assertion_type": "verified_email",
-  "assertion": "user@example.com"
+  "type": "service_auth",
+  "login_hint": "user@example.com"
 }
 ```
 
@@ -213,7 +211,7 @@ Response (200):
 ```json
 {
   "registration_id": "reg_...",
-  "registration_type": "email-verification",
+  "registration_type": "service_auth",
   "claim_url": "https://auth.service.example.com/agent/identity/claim",
   "claim_token": "clm_...",
   "claim_token_expires": "2026-05-21T17:31:25.994Z",
@@ -262,7 +260,7 @@ The end goal: get a signed-in user to confirm a 6-digit `user_code` **you supply
 
 ### 4a. Get the ceremony materials
 
-For **email-verification** registrations, you already have them — they're in the `claim` block of the Step 3 response. Skip to 4b.
+For **service_auth** registrations, you already have them — they're in the `claim` block of the Step 3 response. Skip to 4b.
 
 For **anonymous** registrations, ask the service to start a ceremony:
 
@@ -293,7 +291,7 @@ Response (200):
 }
 ```
 
-The `claim_attempt` block here — same shape as the `claim` block in the email-verification registration response — borrows from [RFC 8628 device-authorization](https://datatracker.ietf.org/doc/html/rfc8628), with `claim_attempt_token` embedded in `verification_uri` so the URL identifies the registration without leaking the user-typed `user_code`. Surface `verification_uri` + `user_code` to the user; poll the standard `token_endpoint` from AS metadata with the claim grant (see 4c).
+The `claim_attempt` block here — same shape as the `claim` block in the `service_auth` registration response — borrows from [RFC 8628 device-authorization](https://datatracker.ietf.org/doc/html/rfc8628), with `claim_attempt_token` embedded in `verification_uri` so the URL identifies the registration without leaking the user-typed `user_code`. Surface `verification_uri` + `user_code` to the user; poll the standard `token_endpoint` from AS metadata with the claim grant (see 4c).
 
 The `email` you supply on anonymous `/claim` binds the registration to the human you intend the agent to act on behalf of — only that signed-in user can complete the ceremony. Without this, a third party who intercepted the `user_code` could claim the agent for themselves.
 
@@ -355,7 +353,7 @@ If the `user_code` window passes without the user finishing:
 
 Two cases distinguish what to do next:
 
-- **Registration is still active** (most common — the user_code's 10-minute timer expired but the outer claim window is still open): call `POST /agent/identity/claim` with the same `claim_token` and the same `email` to mint a fresh `claim_attempt` block. Surface the new `user_code` and `verification_uri` to the user and resume polling. This works for both anonymous and email-verification registrations.
+- **Registration is still active** (most common — the user_code's 10-minute timer expired but the outer claim window is still open): call `POST /agent/identity/claim` with the same `claim_token` and the same `email` to mint a fresh `claim_attempt` block. Surface the new `user_code` and `verification_uri` to the user and resume polling. This works for both anonymous and service_auth registrations.
 - **Registration itself has expired** (the outer claim window — typically 24h — has closed): start over at Step 3.
 
 If you can't tell which it is from context, try re-initiating first; the claim endpoint returns `410 claim_expired` if the registration is gone, at which point you restart at Step 3.
@@ -412,7 +410,7 @@ Errors at `/agent/identity` and `/agent/identity/claim/*` use profile-specific c
 | Code                         | Where                         | What to do                                                                                                                                                                             |
 | ---------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `anonymous_not_enabled`      | `/agent/identity`             | This service doesn't accept anonymous. Pick another method from Step 2.                                                                                                                |
-| `verified_email_not_enabled` | `/agent/identity`             | Email verification disabled here. Pick another method.                                                                                                                                 |
+| `service_auth_not_enabled`   | `/agent/identity`             | service_auth (email-based) disabled here. Pick another method.                                                                                                                         |
 | `issuer_not_enabled`         | `/agent/identity`             | Provider not on this service's trust list. Pick another method.                                                                                                                        |
 | `invalid_request`            | `/agent/identity`             | Body shape, missing claims, ID-JAG signature/`jti`/`aud` problems, or unverified identity. Fix the input (mint a fresh ID-JAG if signature/`jti`/`aud`/`exp`-related).                 |
 | `interaction_required` (401) | `/agent/identity` (ID-JAG)    | Step-up: ID-JAG matched an existing account but no `(iss, sub)` delegation yet. Body carries a `claim` block; surface it to the user (see [Step 4](#step-4--claim-ceremony)).          |

--- a/AUTH.md
+++ b/AUTH.md
@@ -107,7 +107,7 @@ Use this decision tree:
 2. **You have only the user's email** → [service_auth](#service_auth). Claim ceremony required.
 3. **You have neither** → [anonymous](#anonymous). Claim ceremony optional; deferred until the user wants to take ownership.
 
-For `identity_assertion`, cross-check that your assertion type is in `agent_auth.identity_assertion.assertion_types_supported` — trust setup isn't enumerable by trial, so a missing entry means stop. For `service_auth` and `anonymous`, `identity_types_supported` is informational — send the body and fall back on the `*_not_enabled` error if the service opted out.
+For `identity_assertion`, check that your assertion type is in `agent_auth.identity_assertion.assertion_types_supported`, if not listed then stop. For `service_auth` and `anonymous`, `identity_types_supported` is informational — send the body and fall back on the `*_not_enabled` error if the service opted out.
 
 ## Step 3 — Register
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,28 @@
 
 ## v0.7.0 (2026-06-09)
 
-Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band. Also trades the hard wrong-account 403 on `/claim` for soft advisory prompts, so users with multiple accounts at the service can complete the ceremony without re-authenticating.
+Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.
 
 ### Added
 
 - `service_auth` registration type at `/agent/identity` — `{ "type": "service_auth", "login_hint": "<email>" }`. Returns the same ceremony shape the previous email path returned (`claim_token` + `claim` block with `user_code` and `verification_uri`); the agent polls `/oauth2/token` with the claim grant to complete.
 - `/claim` page-level advisories — confirmation prompts rendered above the `user_code` form, each naming a thing the user should notice before authorizing:
-  - `hint_mismatch` — the signed-in account's email doesn't match the registration's `login_hint`.
   - `first_time_provider` — ID-JAG step-up where this `iss` has never been linked to this user before.
   - `first_time_account` — no prior claimed registration exists for this user.
 - `service_auth_not_enabled` error code at `/agent/identity` for services that opt out of the new type.
+- `invalid_login_hint` error code at `/agent/identity` — returned when the supplied `login_hint` doesn't match a recognizable identifier shape (today: an email address).
 
 ### Changed
 
 - Body shape for the email-based path: `{ "type": "identity_assertion", "assertion_type": "verified_email", "assertion": "<email>" }` → `{ "type": "service_auth", "login_hint": "<email>" }`. The body discriminator moves from a nested `assertion_type` to the top-level `type`, and the field follows CIBA's `login_hint` (untyped string — service sniffs format, leaving room for phone numbers etc. later).
 - Response `registration_type`: `"email-verification"` → `"service_auth"`.
 - Discovery: `agent_auth.identity_types_supported` now includes `"service_auth"`. `agent_auth.identity_assertion.assertion_types_supported` drops `"verified_email"` (ID-JAG only now).
-- `/claim` wrong-account check: no longer 403s. The page always renders the user_code form; any mismatch between the signed-in account and the registration's `login_hint` surfaces as a `hint_mismatch` advisory above the form. Typing the code remains the consent gate. **Security trade-off:** weaker than the old hard reject against an attacker who has intercepted the `user_code` — they now get a prompt rather than a block, and the protection depends on the user reading and refusing. The legitimate UX improvement (users with multiple accounts at the service no longer have to sign out and back in) was judged worth it.
 - AUTH.md Step 2 decision-tree: agents cross-check `identity_assertion.assertion_types_supported` (provider trust setup isn't trial-discoverable) but send `service_auth` and `anonymous` without consulting discovery — `identity_types_supported` is informational for those two, and opt-out is signaled by the `*_not_enabled` error.
 
 ### Removed
 
 - `verified_email` assertion type. Migrated to the top-level `service_auth` registration type.
 - `verified_email_not_enabled` error code. Replaced by `service_auth_not_enabled`.
-- The `Wrong account` 403 reject from `/claim`. Replaced by the `hint_mismatch` advisory.
 
 ## v0.5.0 (2026-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # auth.md Changelog
 
-## v0.6.0 (2026-06-12)
+## v0.6.0 (2026-06-10)
 
 Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # auth.md Changelog
 
-## v0.7.0 (2026-06-09)
+## v0.6.0 (2026-06-10)
 
 Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # auth.md Changelog
 
+## v0.7.0 (2026-06-09)
+
+Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band. Also trades the hard wrong-account 403 on `/claim` for soft advisory prompts, so users with multiple accounts at the service can complete the ceremony without re-authenticating.
+
+### Added
+
+- `service_auth` registration type at `/agent/identity` — `{ "type": "service_auth", "login_hint": "<email>" }`. Returns the same ceremony shape the previous email path returned (`claim_token` + `claim` block with `user_code` and `verification_uri`); the agent polls `/oauth2/token` with the claim grant to complete.
+- `/claim` page-level advisories — confirmation prompts rendered above the `user_code` form, each naming a thing the user should notice before authorizing:
+  - `hint_mismatch` — the signed-in account's email doesn't match the registration's `login_hint`.
+  - `first_time_provider` — ID-JAG step-up where this `iss` has never been linked to this user before.
+  - `first_time_account` — no prior claimed registration exists for this user.
+- `service_auth_not_enabled` error code at `/agent/identity` for services that opt out of the new type.
+
+### Changed
+
+- Body shape for the email-based path: `{ "type": "identity_assertion", "assertion_type": "verified_email", "assertion": "<email>" }` → `{ "type": "service_auth", "login_hint": "<email>" }`. The body discriminator moves from a nested `assertion_type` to the top-level `type`, and the field follows CIBA's `login_hint` (untyped string — service sniffs format, leaving room for phone numbers etc. later).
+- Response `registration_type`: `"email-verification"` → `"service_auth"`.
+- Discovery: `agent_auth.identity_types_supported` now includes `"service_auth"`. `agent_auth.identity_assertion.assertion_types_supported` drops `"verified_email"` (ID-JAG only now).
+- `/claim` wrong-account check: no longer 403s. The page always renders the user_code form; any mismatch between the signed-in account and the registration's `login_hint` surfaces as a `hint_mismatch` advisory above the form. Typing the code remains the consent gate. **Security trade-off:** weaker than the old hard reject against an attacker who has intercepted the `user_code` — they now get a prompt rather than a block, and the protection depends on the user reading and refusing. The legitimate UX improvement (users with multiple accounts at the service no longer have to sign out and back in) was judged worth it.
+- AUTH.md Step 2 decision-tree: agents cross-check `identity_assertion.assertion_types_supported` (provider trust setup isn't trial-discoverable) but send `service_auth` and `anonymous` without consulting discovery — `identity_types_supported` is informational for those two, and opt-out is signaled by the `*_not_enabled` error.
+
+### Removed
+
+- `verified_email` assertion type. Migrated to the top-level `service_auth` registration type.
+- `verified_email_not_enabled` error code. Replaced by `service_auth_not_enabled`.
+- The `Wrong account` 403 reject from `/claim`. Replaced by the `hint_mismatch` advisory.
+
 ## v0.5.0 (2026-06-05)
 
 Gates first-time linking of an ID-JAG to an existing account behind a user-confirmation ceremony, and requires fresh `auth_time` on every ID-JAG. Without this confirmation gate, any trusted provider could mint an ID-JAG with `email_verified: true` for a victim's email and silently take over their account. Without the freshness gate, an agent could use a stale upstream session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # auth.md Changelog
 
-## v0.6.0 (2026-06-10)
+## v0.6.0 (2026-06-12)
 
 Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ Hosted at `/.well-known/oauth-authorization-server`:
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion"],
+    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
     "identity_assertion": {
       "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag",
-        "verified_email"
+        "urn:ietf:params:oauth:token-type:id-jag"
       ]
     },
     "events_supported": [
@@ -113,7 +112,7 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
+    Agent->>Service: POST /agent/identity<br/>{ type: service_auth, login_hint: email }
     Service-->>Agent: 200 OK (claim_token, claim: user_code + verification_uri)
     Agent-->>User: Surface user_code + verification_uri
     User->>Service: GET verification_uri (signs in, lands on /claim)

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -85,11 +85,10 @@ Discovery is two-hop:
        "identity_endpoint": "https://auth.service.example.com/agent/identity",
        "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
        "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-       "identity_types_supported": ["anonymous", "identity_assertion"],
+       "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
        "identity_assertion": {
          "assertion_types_supported": [
-           "urn:ietf:params:oauth:token-type:id-jag",
-           "verified_email"
+           "urn:ietf:params:oauth:token-type:id-jag"
          ]
        },
        "events_supported": [

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -84,7 +84,7 @@ sequenceDiagram
     participant Agent
     participant Service
 
-    Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion_type: verified_email, assertion: email }
+    Agent->>Service: POST /agent/identity<br/>{ type: service_auth, login_hint: email }
     Service-->>Agent: 200 OK (claim_token, claim: user_code, verification_uri)
     Agent-->>User: Surface user_code + verification_uri
     User->>Service: GET verification_uri (signs in as asserted email, lands on /claim)
@@ -153,11 +153,10 @@ AS metadata:
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion"],
+    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
     "identity_assertion": {
       "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag",
-        "verified_email"
+        "urn:ietf:params:oauth:token-type:id-jag"
       ]
     },
     "events_supported": [
@@ -317,21 +316,20 @@ Successful response:
 
 See [Claim Ceremony](#claim-ceremony) for the `/agent/identity/claim` init and the agent's poll loop. After a successful claim the agent re-exchanges the same `identity_assertion` at `/oauth2/token` to pick up the `post_claim_scopes`.
 
-#### type: identity_assertion (verified email)
+#### type: service_auth
 
 Request:
 
 ```json
 {
-  "type": "identity_assertion",
-  "assertion_type": "verified_email",
-  "assertion": "user@example.com"
+  "type": "service_auth",
+  "login_hint": "user@example.com"
 }
 ```
 
 Implementation steps:
 
-1. Create a registration row marked as `email-verification` and persist the asserted email as `claim_email`.
+1. Create a registration row marked as `service_auth` and persist the asserted email as `claim_email`.
 2. Generate a `claim_token` (returned to the agent), a `claim_attempt_token` (embedded in `verification_uri`), and a 6-digit `user_code`. Store SHA-256 hashes of all three; return the plaintext `claim_token` and `user_code` in the response, embed the `claim_attempt_token` in the `verification_uri`.
 3. Return the claim handles + a `claim` block (see [Claim Ceremony](#claim-ceremony)) — but **no identity_assertion**. The assertion is minted when the user completes the ceremony and the agent polls `/oauth2/token` with the claim grant.
 
@@ -340,7 +338,7 @@ Successful response:
 ```json
 {
   "registration_id": "reg_01ABC...",
-  "registration_type": "email-verification",
+  "registration_type": "service_auth",
   "claim_url": "/agent/identity/claim",
   "claim_token": "clm_abc123...",
   "claim_token_expires": "2026-04-22T12:34:56.789Z",
@@ -446,7 +444,7 @@ Reject ID-JAGs with neither a verified email nor a verified phone — there's no
 
 ### Claim Ceremony
 
-Both `anonymous` and `verified_email` flows funnel into the same ceremony: the service mints a `user_code`, the agent surfaces it to the user along with a `verification_uri`, the user signs in to the service and types the code on a service-owned form, the agent polls for completion. The ceremony fields (`user_code`, `verification_uri`, `expires_in`, `interval`) borrow from [RFC 8628 device authorization](https://datatracker.ietf.org/doc/html/rfc8628), and polling happens at the standard `token_endpoint` with a profile-specific grant (`urn:workos:agent-auth:grant-type:claim`).
+Both `anonymous` and `service_auth` flows funnel into the same ceremony: the service mints a `user_code`, the agent surfaces it to the user along with a `verification_uri`, the user signs in to the service and types the code on a service-owned form, the agent polls for completion. The ceremony fields (`user_code`, `verification_uri`, `expires_in`, `interval`) borrow from [RFC 8628 device authorization](https://datatracker.ietf.org/doc/html/rfc8628), and polling happens at the standard `token_endpoint` with a profile-specific grant (`urn:workos:agent-auth:grant-type:claim`).
 
 
 **Why a profile-specific grant URN.** Polling could in principle reuse `urn:ietf:params:oauth:grant-type:device_code`, but a service implementing standard RFC 8628 device authorization at the same token endpoint would then have to disambiguate by inspecting the bearer value (claim_token vs device_code). A custom URN routes by grant_type, which is where OAuth implementations already dispatch — no collision risk.
@@ -458,7 +456,7 @@ Both `anonymous` and `verified_email` flows funnel into the same ceremony: the s
 
 #### Ceremony block shape
 
-Returned nested under `claim` (email-verification registration response) or `claim_attempt` (anonymous `/claim` response):
+Returned nested under `claim` (service_auth registration response) or `claim_attempt` (anonymous `/claim` response):
 
 ```json
 {
@@ -568,7 +566,7 @@ Implementation notes:
 
 - Look up the registration by `sha256(claim_token)`. If absent → `expired_token`. If `status === "expired"` → `expired_token`. If `status !== "claimed"` → `authorization_pending`. If claimed → mint a fresh access_token and a fresh identity_assertion.
 - For **anonymous**, on completion the pre-claim access_tokens (from earlier jwt-bearer exchanges) should be **revoked** — the canonical credential is the one returned here. The v2 identity_assertion includes the now-known `email` / `email_verified` claims; the v1 the agent held has neither.
-- For **email-verification**, this is the first time an identity_assertion exists for this registration — the agent uses it for jwt-bearer refreshes once the returned access_token expires.
+- For **service_auth**, this is the first time an identity_assertion exists for this registration — the agent uses it for jwt-bearer refreshes once the returned access_token expires.
 - Honor RFC 8628's `interval` — return `{ "error": "slow_down" }` if the agent polls faster than advertised.
 - Emit `claim.confirmed` (see [Recommended Audit Events](#recommended-audit-events)).
 
@@ -633,7 +631,7 @@ Record the following state transitions for observability and incident response. 
 | `assertion.issued`     | A service-signed identity_assertion is minted               | `registration_id`                       |
 | `token.issued`         | `/oauth2/token` returns an access_token                     | `registration_id`, `scope`              |
 | `token.revoked`        | `/oauth2/revoke` invalidates a credential                   | `registration_id`                       |
-| `claim.requested`      | `/agent/identity/claim` called (or implicit on email-verification) | `registration_id`, `email`              |
+| `claim.requested`      | `/agent/identity/claim` called (or implicit on service_auth)       | `registration_id`, `email`              |
 | `user_code.minted`     | user_code minted at ceremony start                          | `registration_id`                       |
 | `claim.confirmed`      | `/agent/identity/claim/complete` succeeds                   | `registration_id`, `claimed_by_user_id` |
 | `registration.expired` | Unclaimed registration past its TTL                         | `registration_id`                       |

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -4,6 +4,7 @@ import { matchOrProvision } from "../matcher.js";
 import { agentAuthBody, claimBody, parseBody } from "../schemas.js";
 import {
   type Registration,
+  classifyLoginHint,
   createAnonymousRegistration,
   createServiceAuthRegistration,
   findOrCreateIdJagRegistration,
@@ -215,16 +216,26 @@ async function handleServiceAuth(
   body: { login_hint: string },
   res: express.Response,
 ): Promise<void> {
+  const login_hint = classifyLoginHint(body.login_hint);
+  if (!login_hint) {
+    res.status(400).json({
+      error: "invalid_login_hint",
+      message:
+        "login_hint must be a recognizable identifier (e.g. an email address).",
+    });
+    return;
+  }
+
   const {
     registration,
     claimTokenPlaintext,
     claimViewTokenPlaintext,
     userCode,
     userCodeExpiresAt,
-  } = createServiceAuthRegistration({ email: body.login_hint });
+  } = createServiceAuthRegistration({ login_hint });
 
   console.log(
-    `[agent-auth] service_auth registration=${registration.id} login_hint=${body.login_hint}`,
+    `[agent-auth] service_auth registration=${registration.id} login_hint=${login_hint.value}`,
   );
 
   res.json({
@@ -279,32 +290,15 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     return;
   }
   /*
-   * Email is immutable once bound. For service_auth it's bound at
-   * registration time (from the agent's identity claim). For anonymous
-   * it's bound on the first /claim call; subsequent re-initiations must
-   * supply the same email — otherwise an agent could redirect the
-   * ceremony from the originally-bound user to a different account,
-   * defeating the wrong-account check in /claim.
+   * Mint a fresh ceremony (new claim_attempt_token + new user_code). The
+   * login_hint is per-attempt — a re-initiation may supply a corrected
+   * email; only the current attempt's view_token and user_code work, and
+   * the /claim page surfaces the current attempt's hint as an advisory.
    */
-  if (
-    registration.claim?.email &&
-    registration.claim.email !== parsed.value.email
-  ) {
-    res.status(400).json({
-      error: "email_mismatch",
-      message:
-        "The supplied email does not match the registration's bound email.",
-    });
-    return;
-  }
-
-  /*
-   * Mint a fresh ceremony (new claim_attempt_token + new user_code). For
-   * anonymous this binds the supplied email; for service_auth it refreshes
-   * an expired user_code without changing the bound email. Any prior URL
-   * stops working.
-   */
-  const fresh = recordClaimAttempt(registration, parsed.value.email);
+  const fresh = recordClaimAttempt(registration, {
+    kind: "email",
+    value: parsed.value.email,
+  });
   const attempt = registration.claim!.attempt!;
 
   console.log(

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -1,16 +1,11 @@
 import express, { Router } from "express";
 import { config } from "../config.js";
 import { matchOrProvision } from "../matcher.js";
-import {
-  ASSERTION_TYPES,
-  agentAuthBody,
-  claimBody,
-  parseBody,
-} from "../schemas.js";
+import { agentAuthBody, claimBody, parseBody } from "../schemas.js";
 import {
   type Registration,
   createAnonymousRegistration,
-  createEmailVerificationRegistration,
+  createServiceAuthRegistration,
   findOrCreateIdJagRegistration,
   findRegistrationByClaimHash,
   recordClaimAttempt,
@@ -48,10 +43,10 @@ agentAuthRouter.post(config.identityEndpointPath, async (req, res) => {
   }
 
   if (parsed.value.type === "identity_assertion") {
-    if (parsed.value.assertion_type === ASSERTION_TYPES.EMAIL_ASSERTION) {
-      return handleEmailAssertion(parsed.value, res);
-    }
     return handleIdJagAssertion(parsed.value, res);
+  }
+  if (parsed.value.type === "service_auth") {
+    return handleServiceAuth(parsed.value, res);
   }
 
   const { registration, claimTokenPlaintext } = createAnonymousRegistration();
@@ -216,8 +211,8 @@ function escapeHeader(s: string): string {
   return s.replace(/[\\"]/g, "\\$&");
 }
 
-async function handleEmailAssertion(
-  body: { assertion: string },
+async function handleServiceAuth(
+  body: { login_hint: string },
   res: express.Response,
 ): Promise<void> {
   const {
@@ -226,15 +221,15 @@ async function handleEmailAssertion(
     claimViewTokenPlaintext,
     userCode,
     userCodeExpiresAt,
-  } = createEmailVerificationRegistration({ email: body.assertion });
+  } = createServiceAuthRegistration({ email: body.login_hint });
 
   console.log(
-    `[agent-auth] email-verification registration=${registration.id} email=${body.assertion}`,
+    `[agent-auth] service_auth registration=${registration.id} login_hint=${body.login_hint}`,
   );
 
   res.json({
     registration_id: registration.id,
-    registration_type: "email-verification",
+    registration_type: "service_auth",
     claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
     claim_token: claimTokenPlaintext,
     claim_token_expires: registration.claim!.expires_at.toISOString(),
@@ -251,7 +246,7 @@ async function handleEmailAssertion(
  * Initiates or re-mints a claim ceremony. Two registration kinds reach here:
  *   - anonymous: first initiation (binds the email) or refresh (after the
  *     user_code window closed before the user could complete).
- *   - email_verification: refresh only (the initial ceremony was minted at
+ *   - service_auth: refresh only (the initial ceremony was minted at
  *     /agent/identity); the supplied email must match the registration.
  */
 agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
@@ -284,7 +279,7 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
     return;
   }
   /*
-   * Email is immutable once bound. For email_verification it's bound at
+   * Email is immutable once bound. For service_auth it's bound at
    * registration time (from the agent's identity claim). For anonymous
    * it's bound on the first /claim call; subsequent re-initiations must
    * supply the same email — otherwise an agent could redirect the
@@ -305,7 +300,7 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
 
   /*
    * Mint a fresh ceremony (new claim_attempt_token + new user_code). For
-   * anonymous this binds the supplied email; for email-verification it refreshes
+   * anonymous this binds the supplied email; for service_auth it refreshes
    * an expired user_code without changing the bound email. Any prior URL
    * stops working.
    */

--- a/agent-services/src/routes/claim.ts
+++ b/agent-services/src/routes/claim.ts
@@ -6,7 +6,9 @@ import {
   type Registration,
   type User,
   completeClaim,
+  delegations,
   findRegistrationByClaimViewHash,
+  registrations,
   sha256Hex,
   users,
 } from "../store.js";
@@ -77,50 +79,86 @@ claimRouter.get("/claim", (req, res) => {
     return;
   }
 
-  /*
-   * Agent asserted a specific email — only that signed-in user can complete.
-   * Applies to both email_verification (email is the agent's identity claim)
-   * and anonymous (email binds the registration to the human the agent
-   * surfaced the user_code to, preventing third-party claim hijacks).
-   */
-  const wrongAccount = wrongAccountError(registration, user);
-  if (wrongAccount) {
-    res.status(403).type("html").send(wrongAccount);
-    return;
-  }
-
   res.type("html").send(
     renderClaimPage({
       status: "form",
-      ...promptCopy(registration, user),
+      title: "Authorize this agent?",
+      message: `You're signed in as <code>${escapeHtml(user.email)}</code>. The agent should have shown you a 6-digit code — enter it below to authorize it to act on your behalf.`,
+      advisories: computeAdvisories(registration, user),
       claimAttemptToken: token,
     }),
   );
 });
 
-/**
- * Wording for the claim form. ID-JAG step-up registrations name the
- * provider being linked ("Cursor is asking to link this account…");
- * anonymous and verified-email use generic copy. Provider name comes from
- * the service's trust list, not from anywhere the provider controls
- * directly (in production this would typically resolve via CIMD with the
- * service still gating which client_name values it renders).
+/*
+ * Advisories surface above the form. They don't block — typing the code is
+ * still the confirm action — but each one names a thing the user should
+ * notice before authorizing: a login_hint that doesn't match the signed-in
+ * account, the first time any agent is being linked to this account, or
+ * the first time a particular provider (ID-JAG iss) is being linked.
+ *
+ * The user_code on the form is the consent gate; the advisories are the
+ * "before you type, here's what's actually happening" context. Provider
+ * name comes from the service's trust list, never from anything the
+ * provider supplies in the ID-JAG.
  */
-function promptCopy(
+type Advisory =
+  | { kind: "hint_mismatch"; hintEmail: string; userEmail: string }
+  | { kind: "first_time_account"; userEmail: string }
+  | { kind: "first_time_provider"; providerName: string; userEmail: string };
+
+function computeAdvisories(
   registration: Registration,
   user: User,
-): { title: string; message: string } {
-  if (registration.kind === "id_jag" && registration.id_jag) {
-    const provider = trustedIssuerDisplayName(registration.id_jag.iss);
-    return {
-      title: `Link ${escapeHtml(provider)} to your account?`,
-      message: `You're signed in as <code>${escapeHtml(user.email)}</code>. <strong>${escapeHtml(provider)}</strong> is asking to link this account so an agent running there can act on your behalf. Enter the 6-digit code your agent showed you to confirm.`,
-    };
+): Advisory[] {
+  const out: Advisory[] = [];
+
+  const hintEmail = registration.claim?.email;
+  if (hintEmail && hintEmail.toLowerCase() !== user.email.toLowerCase()) {
+    out.push({ kind: "hint_mismatch", hintEmail, userEmail: user.email });
   }
-  return {
-    title: "Confirm the code from your agent",
-    message: `You're signed in as <code>${escapeHtml(user.email)}</code>. The agent should have shown you a 6-digit code — enter it below to authorize it to act on your behalf.`,
-  };
+
+  if (registration.kind === "id_jag" && registration.id_jag) {
+    const iss = registration.id_jag.iss;
+    let providerLinked = false;
+    for (const d of delegations.values()) {
+      if (d.iss === iss && d.user_id === user.id) {
+        providerLinked = true;
+        break;
+      }
+    }
+    if (!providerLinked) {
+      out.push({
+        kind: "first_time_provider",
+        providerName: trustedIssuerDisplayName(iss),
+        userEmail: user.email,
+      });
+    }
+  }
+
+  let anyPriorClaim = false;
+  for (const r of registrations.values()) {
+    if (r.user_id === user.id && r.claimed_at && r.id !== registration.id) {
+      anyPriorClaim = true;
+      break;
+    }
+  }
+  if (!anyPriorClaim) {
+    out.push({ kind: "first_time_account", userEmail: user.email });
+  }
+
+  return out;
+}
+
+function renderAdvisory(a: Advisory): string {
+  switch (a.kind) {
+    case "hint_mismatch":
+      return `The agent hinted that this claim was for <code>${escapeHtml(a.hintEmail)}</code>, but you're signed in as <code>${escapeHtml(a.userEmail)}</code>. If you authorize now, the agent will be bound to <code>${escapeHtml(a.userEmail)}</code>.`;
+    case "first_time_provider":
+      return `<strong>${escapeHtml(a.providerName)}</strong> has never been linked to <code>${escapeHtml(a.userEmail)}</code> before. Authorizing here lets agents running on ${escapeHtml(a.providerName)} act on your behalf at this service in the future.`;
+    case "first_time_account":
+      return `This is the first agent being linked to <code>${escapeHtml(a.userEmail)}</code>.`;
+  }
 }
 
 /*
@@ -167,12 +205,6 @@ claimRouter.post(`${config.claimEndpointPath}/complete`, (req, res) => {
     return;
   }
 
-  const wrongAccount = wrongAccountError(registration, user);
-  if (wrongAccount) {
-    res.status(403).type("html").send(wrongAccount);
-    return;
-  }
-
   const result = completeClaim(registration, parsed.value.user_code, user);
   if (!result.ok) {
     res
@@ -181,7 +213,9 @@ claimRouter.post(`${config.claimEndpointPath}/complete`, (req, res) => {
       .send(
         renderClaimPage({
           status: "form-error",
-          ...promptCopy(registration, user),
+          title: "Authorize this agent?",
+          message: `You're signed in as <code>${escapeHtml(user.email)}</code>. The agent should have shown you a 6-digit code — enter it below to authorize it to act on your behalf.`,
+          advisories: computeAdvisories(registration, user),
           claimAttemptToken: parsed.value.claim_attempt_token,
           error: humanError(result.error),
         }),
@@ -228,20 +262,6 @@ function returnToFor(token: string): string {
   return `/claim?claim_attempt_token=${encodeURIComponent(token)}`;
 }
 
-function wrongAccountError(
-  registration: Registration,
-  user: User,
-): string | undefined {
-  const claimEmail = registration.claim?.email;
-  if (!claimEmail) return undefined;
-  if (claimEmail.toLowerCase() === user.email.toLowerCase()) return undefined;
-  return renderClaimPage({
-    status: "error",
-    title: "Wrong account",
-    message: `This claim was started for <code>${escapeHtml(claimEmail)}</code>. You're signed in as <code>${escapeHtml(user.email)}</code>. Sign out and sign back in with the right account.`,
-  });
-}
-
 function statusForError(error: string): number {
   switch (error) {
     case "user_code_invalid":
@@ -275,11 +295,16 @@ function renderClaimPage(input: {
   status: "form" | "form-error" | "done" | "error";
   title: string;
   message: string;
+  advisories?: Advisory[];
   claimAttemptToken?: string;
   error?: string;
 }): string {
   const isError = input.status === "error";
   const headingColor = isError ? "var(--error)" : "var(--brand-primary)";
+
+  const advisoryBlock = (input.advisories ?? [])
+    .map((a) => `<div class="advisory">${renderAdvisory(a)}</div>`)
+    .join("\n");
 
   const formBlock =
     input.status === "form" || input.status === "form-error"
@@ -336,11 +361,14 @@ function renderClaimPage(input: {
   button:hover { filter: brightness(1.08); }
   .err { color: var(--error); background: rgba(229, 80, 57, .08); border: 1px solid rgba(229, 80, 57, .35); padding: .5rem .75rem; border-radius: .35rem; font-size: .85rem; margin: 0; }
   .warn { background: var(--warn-bg); border: 1px solid var(--warn-border); color: var(--warn-text); padding: .6rem .8rem; border-radius: .35rem; font-size: .8rem; margin-top: 1rem; }
+  .advisory { background: var(--warn-bg); border: 1px solid var(--warn-border); color: var(--warn-text); padding: .65rem .8rem; border-radius: .35rem; font-size: .85rem; margin: .5rem 0; }
+  .advisory + .advisory { margin-top: .4rem; }
 </style>
 </head>
 <body>
 <h1>${escapeHtml(input.title)}</h1>
 <p>${input.message}</p>
+${advisoryBlock}
 ${formBlock}
 </body></html>`;
 }

--- a/agent-services/src/routes/claim.ts
+++ b/agent-services/src/routes/claim.ts
@@ -78,6 +78,10 @@ claimRouter.get("/claim", (req, res) => {
       );
     return;
   }
+  if (hintMismatch(attempt.login_hint, user)) {
+    res.status(403).type("html").send(renderWrongAccount(attempt.login_hint!));
+    return;
+  }
 
   res.type("html").send(
     renderClaimPage({
@@ -93,17 +97,16 @@ claimRouter.get("/claim", (req, res) => {
 /*
  * Advisories surface above the form. They don't block — typing the code is
  * still the confirm action — but each one names a thing the user should
- * notice before authorizing: a login_hint that doesn't match the signed-in
- * account, the first time any agent is being linked to this account, or
- * the first time a particular provider (ID-JAG iss) is being linked.
+ * notice before authorizing: the first time any agent is being linked to
+ * this account, or the first time a particular provider (ID-JAG iss) is
+ * being linked.
  *
- * The user_code on the form is the consent gate; the advisories are the
- * "before you type, here's what's actually happening" context. Provider
- * name comes from the service's trust list, never from anything the
- * provider supplies in the ID-JAG.
+ * Wrong-account is *not* an advisory: a login_hint that doesn't match the
+ * signed-in user is a hard reject upstream of this function — the form
+ * never renders in that case. Provider name comes from the service's trust
+ * list, never from anything the provider supplies in the ID-JAG.
  */
 type Advisory =
-  | { kind: "hint_mismatch"; hintEmail: string; userEmail: string }
   | { kind: "first_time_account"; userEmail: string }
   | { kind: "first_time_provider"; providerName: string; userEmail: string };
 
@@ -112,11 +115,6 @@ function computeAdvisories(
   user: User,
 ): Advisory[] {
   const out: Advisory[] = [];
-
-  const hintEmail = registration.claim?.email;
-  if (hintEmail && hintEmail.toLowerCase() !== user.email.toLowerCase()) {
-    out.push({ kind: "hint_mismatch", hintEmail, userEmail: user.email });
-  }
 
   if (registration.kind === "id_jag" && registration.id_jag) {
     const iss = registration.id_jag.iss;
@@ -152,13 +150,29 @@ function computeAdvisories(
 
 function renderAdvisory(a: Advisory): string {
   switch (a.kind) {
-    case "hint_mismatch":
-      return `The agent hinted that this claim was for <code>${escapeHtml(a.hintEmail)}</code>, but you're signed in as <code>${escapeHtml(a.userEmail)}</code>. If you authorize now, the agent will be bound to <code>${escapeHtml(a.userEmail)}</code>.`;
     case "first_time_provider":
       return `<strong>${escapeHtml(a.providerName)}</strong> has never been linked to <code>${escapeHtml(a.userEmail)}</code> before. Authorizing here lets agents running on ${escapeHtml(a.providerName)} act on your behalf at this service in the future.`;
     case "first_time_account":
       return `This is the first agent being linked to <code>${escapeHtml(a.userEmail)}</code>.`;
   }
+}
+
+function hintMismatch(
+  hint: { kind: "email"; value: string } | undefined,
+  user: User,
+): boolean {
+  return (
+    hint?.kind === "email" &&
+    hint.value.toLowerCase() !== user.email.toLowerCase()
+  );
+}
+
+function renderWrongAccount(hint: { kind: "email"; value: string }): string {
+  return renderClaimPage({
+    status: "error",
+    title: "Wrong account",
+    message: `This claim was started for <code>${escapeHtml(hint.value)}</code>. Sign out and sign back in as that account to authorize the agent.`,
+  });
 }
 
 /*
@@ -202,6 +216,12 @@ claimRouter.post(`${config.claimEndpointPath}/complete`, (req, res) => {
             "This claim link is no longer valid. Ask the agent to start a new claim.",
         }),
       );
+    return;
+  }
+
+  const hint = registration.claim?.attempt?.login_hint;
+  if (hintMismatch(hint, user)) {
+    res.status(403).type("html").send(renderWrongAccount(hint!));
     return;
   }
 

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -189,7 +189,7 @@ Content-Type: application/json
 
 <section id="step-10" class="track-email" hidden>
   <h2><span class="num">10</span>Register with an email assertion</h2>
-  <p>The agent has the user's email but no provider-signed assertion. It POSTs <code>/agent/identity</code> with <code>assertion_type: verified_email</code>. The response bundles the ceremony block (<code>user_code</code>, <code>verification_uri</code>, <code>interval</code>) — no separate <code>/claim</code> call needed.</p>
+  <p>The agent has the user's email but no provider-signed assertion. It POSTs <code>/agent/identity</code> with <code>type: service_auth</code>. The response bundles the ceremony block (<code>user_code</code>, <code>verification_uri</code>, <code>interval</code>) — no separate <code>/claim</code> call needed.</p>
   <label>User email
     <input id="email-assertion" value="alice@example.com">
   </label>
@@ -349,9 +349,8 @@ function updateAnonClaimPreview() {
 }
 function updateEmailRegisterPreview() {
   const body = {
-    type: "identity_assertion",
-    assertion_type: "verified_email",
-    assertion: document.getElementById("email-assertion").value,
+    type: "service_auth",
+    login_hint: document.getElementById("email-assertion").value,
   };
   document.querySelector("#email-register-req pre").textContent =
     "POST /agent/identity\\nContent-Type: application/json\\n\\n" + jsonStr(body);
@@ -511,9 +510,8 @@ async function anonCallPost() {
 async function emailRegister() {
   const email = document.getElementById("email-assertion").value.trim();
   const body = {
-    type: "identity_assertion",
-    assertion_type: "verified_email",
-    assertion: email,
+    type: "service_auth",
+    login_hint: email,
   };
   const r = await jsonFetch("/agent/identity", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("email-register-out").innerHTML = resBlock(r.status, null, r.body, r.ok);

--- a/agent-services/src/routes/token.ts
+++ b/agent-services/src/routes/token.ts
@@ -288,8 +288,8 @@ tokenRouter.post(config.revocationEndpointPath, formParser, (req, res) => {
 });
 
 function sourceForRegistrationKind(
-  kind: "anonymous" | "email_verification" | "id_jag",
-): "anonymous" | "email_verification" | "identity_assertion" {
+  kind: "anonymous" | "service_auth" | "id_jag",
+): "anonymous" | "service_auth" | "identity_assertion" {
   if (kind === "id_jag") return "identity_assertion";
   return kind;
 }

--- a/agent-services/src/routes/well-known.ts
+++ b/agent-services/src/routes/well-known.ts
@@ -37,12 +37,13 @@ wellKnownRouter.get("/.well-known/oauth-authorization-server", (_req, res) => {
       identity_endpoint: `${config.baseUrl}${config.identityEndpointPath}`,
       claim_endpoint: `${config.baseUrl}${config.claimEndpointPath}`,
       events_endpoint: `${config.baseUrl}${config.eventsEndpointPath}`,
-      identity_types_supported: ["anonymous", "identity_assertion"],
+      identity_types_supported: [
+        "anonymous",
+        "identity_assertion",
+        "service_auth",
+      ],
       identity_assertion: {
-        assertion_types_supported: [
-          "urn:ietf:params:oauth:token-type:id-jag",
-          "verified_email",
-        ],
+        assertion_types_supported: ["urn:ietf:params:oauth:token-type:id-jag"],
       },
       events_supported: [IDENTITY_ASSERTION_REVOKED_SCHEMA],
     },

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 const ID_JAG = "urn:ietf:params:oauth:token-type:id-jag";
-const EMAIL_ASSERTION = "verified_email";
 
 const idJagAssertionBody = z.object({
   type: z.literal("identity_assertion"),
@@ -9,10 +8,9 @@ const idJagAssertionBody = z.object({
   assertion: z.string().min(1),
 });
 
-const emailAssertionBody = z.object({
-  type: z.literal("identity_assertion"),
-  assertion_type: z.literal(EMAIL_ASSERTION),
-  assertion: z.email(),
+const serviceAuthBody = z.object({
+  type: z.literal("service_auth"),
+  login_hint: z.email(),
 });
 
 const anonymousBody = z.object({
@@ -21,7 +19,7 @@ const anonymousBody = z.object({
 
 export const agentAuthBody = z.union([
   idJagAssertionBody,
-  emailAssertionBody,
+  serviceAuthBody,
   anonymousBody,
 ]);
 
@@ -71,7 +69,7 @@ export const revocationEndpointBody = z.object({
   token_type_hint: z.literal("access_token").optional(),
 });
 
-export const ASSERTION_TYPES = { ID_JAG, EMAIL_ASSERTION } as const;
+export const ASSERTION_TYPES = { ID_JAG } as const;
 
 export function parseBody<T>(
   schema: z.ZodType<T>,

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -10,7 +10,7 @@ const idJagAssertionBody = z.object({
 
 const serviceAuthBody = z.object({
   type: z.literal("service_auth"),
-  login_hint: z.email(),
+  login_hint: z.string().min(1),
 });
 
 const anonymousBody = z.object({

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -40,6 +40,22 @@ export type RegistrationKind = "anonymous" | "service_auth" | "id_jag";
  * the agent surfaces to the user. Naming follows RFC 8628 device
  * authorization.
  */
+/**
+ * The identifier the agent hinted at — used to surface a mismatch advisory
+ * if the signed-in user doesn't match. The wire stays a CIBA-shaped opaque
+ * string; routes call `classifyLoginHint` at the edge to tag it. Structured
+ * so adding `kind: "phone"` etc. only touches the classifier.
+ */
+export type LoginHint = { kind: "email"; value: string };
+
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function classifyLoginHint(s: string): LoginHint | undefined {
+  const value = s.trim();
+  if (EMAIL_SHAPE.test(value)) return { kind: "email", value };
+  return undefined;
+}
+
 export type RegistrationClaimAttempt = {
   id: string;
   /** Hash of the claim_attempt_token embedded in the verification URL. */
@@ -49,17 +65,21 @@ export type RegistrationClaimAttempt = {
   user_code_hash: string;
   user_code_generated_at: Date;
   user_code_expires_at: Date;
+  /**
+   * The hint the agent supplied when minting this attempt. Per-attempt so a
+   * re-mint can carry a corrected hint without affecting prior attempts.
+   */
+  login_hint?: LoginHint;
 };
 
 /**
  * The agent-facing leg of the claim ceremony. The agent holds the claim
- * token; the email recipient holds the view token (inside the attempt). For
- * anonymous registrations the email/attempt aren't populated until the agent
- * initiates claim via /agent/identity/claim.
+ * token; the user-facing attempt holds the view token, the user_code, and
+ * the agent's hint. For anonymous registrations the attempt isn't populated
+ * until the agent initiates claim via /agent/identity/claim.
  */
 export type RegistrationClaim = {
   token_hash: string;
-  email?: string;
   expires_at: Date;
   attempt?: RegistrationClaimAttempt;
 };
@@ -312,7 +332,7 @@ export function createAnonymousRegistration(): {
  * and surfaces both to the user. The user signs in to the service, types the
  * code on the claim page, and ownership transfers.
  */
-export function createServiceAuthRegistration(input: { email: string }): {
+export function createServiceAuthRegistration(input: { login_hint: LoginHint }): {
   registration: Registration;
   claimTokenPlaintext: string;
   claimViewTokenPlaintext: string;
@@ -331,7 +351,6 @@ export function createServiceAuthRegistration(input: { email: string }): {
     created_at: now,
     claim: {
       token_hash: sha256Hex(claimTokenPlaintext),
-      email: input.email,
       expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
       attempt: {
         id: `cla_${randomBytes(16).toString("base64url")}`,
@@ -342,6 +361,7 @@ export function createServiceAuthRegistration(input: { email: string }): {
         user_code_hash: code.hash,
         user_code_generated_at: now,
         user_code_expires_at: code.expiresAt,
+        login_hint: input.login_hint,
       },
     },
   });
@@ -506,7 +526,7 @@ export function findRegistrationByClaimViewHash(
 
 export function recordClaimAttempt(
   registration: Registration,
-  email: string,
+  login_hint: LoginHint,
 ): {
   claimViewTokenPlaintext: string;
   userCode: string;
@@ -518,7 +538,6 @@ export function recordClaimAttempt(
   const now = new Date();
   const plaintext = `cvt_${randomBytes(24).toString("base64url")}`;
   const code = mintUserCode(now);
-  registration.claim.email = email;
   registration.claim.attempt = {
     id: `cla_${randomBytes(16).toString("base64url")}`,
     view_token_hash: sha256Hex(plaintext),
@@ -528,6 +547,7 @@ export function recordClaimAttempt(
     user_code_hash: code.hash,
     user_code_generated_at: now,
     user_code_expires_at: code.expiresAt,
+    login_hint,
   };
   return {
     claimViewTokenPlaintext: plaintext,

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -454,7 +454,6 @@ export function findOrCreateIdJagRegistration(input: {
   const code = mintUserCode(now);
   const claim = {
     token_hash: sha256Hex(claimTokenPlaintext),
-    email: input.context.email,
     expires_at: new Date(now.getTime() + config.anonymousTtlSeconds * 1000),
     attempt: {
       id: `cla_${randomBytes(16).toString("base64url")}`,
@@ -465,6 +464,7 @@ export function findOrCreateIdJagRegistration(input: {
       user_code_hash: code.hash,
       user_code_generated_at: now,
       user_code_expires_at: code.expiresAt,
+      login_hint: { kind: "email" as const, value: input.context.email },
     },
   };
 

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -17,7 +17,7 @@ export type Credential = {
   issued_at: Date;
   expires_at?: Date;
   revoked: boolean;
-  source: "identity_assertion" | "anonymous" | "email_verification";
+  source: "identity_assertion" | "anonymous" | "service_auth";
   iss?: string;
   sub?: string;
   aud?: string;
@@ -32,7 +32,7 @@ export type Delegation = {
   last_seen: Date;
 };
 
-export type RegistrationKind = "anonymous" | "email_verification" | "id_jag";
+export type RegistrationKind = "anonymous" | "service_auth" | "id_jag";
 
 /**
  * The user-facing leg of the claim ceremony. Tracks the `claim_attempt_token`
@@ -206,7 +206,7 @@ export function issueAccessToken(input: {
   /** Optional: anonymous registrations (pre-claim) have no bound user yet. */
   userId?: string;
   scope: string[];
-  source: "identity_assertion" | "email_verification" | "anonymous";
+  source: "identity_assertion" | "service_auth" | "anonymous";
   iss?: string;
   sub?: string;
   aud?: string;
@@ -307,12 +307,12 @@ export function createAnonymousRegistration(): {
 }
 
 /**
- * Email-verification registrations bundle the claim ceremony: the agent
+ * service_auth registrations bundle the claim ceremony: the agent
  * receives a `user_code` and `verification_uri` in the registration response
  * and surfaces both to the user. The user signs in to the service, types the
  * code on the claim page, and ownership transfers.
  */
-export function createEmailVerificationRegistration(input: { email: string }): {
+export function createServiceAuthRegistration(input: { email: string }): {
   registration: Registration;
   claimTokenPlaintext: string;
   claimViewTokenPlaintext: string;
@@ -327,7 +327,7 @@ export function createEmailVerificationRegistration(input: { email: string }): {
 
   const registration = new Registration({
     id: registrationId,
-    kind: "email_verification",
+    kind: "service_auth",
     created_at: now,
     claim: {
       token_hash: sha256Hex(claimTokenPlaintext),
@@ -369,7 +369,7 @@ function idJagRegistrationKey(iss: string, sub: string, aud: string): string {
  *    delegation or JIT-provisioned). No ceremony; mark claimed.
  *  - `{ email }` — the matcher found an account matching the ID-JAG's
  *    verified email/phone but no delegation yet. The user must confirm via
- *    the same user_code ceremony email-verification uses. Returns the
+ *    the same user_code ceremony service_auth uses. Returns the
  *    ceremony plaintexts so the route can surface them to the agent.
  *
  * On step-up retry (second presentation while a ceremony is in flight),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-md",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "pnpm --filter shared build && concurrently --names agent-provider,agent-service --prefix-colors blue,magenta \"pnpm --filter agent-providers dev\" \"pnpm --filter agent-services dev\"",


### PR DESCRIPTION
- [ ] QA'd in a deployed environment

## Summary

Promotes the email-based registration path out from under `identity_assertion` and into a top-level `service_auth` registration type with a CIBA-style `login_hint` body. The previous shape filed verified-email under `identity_assertion` like the agent was asserting something, but the agent is really just hinting at who the user is — the service does the verifying. CIBA's vocabulary fits, so this aligns with it. See the v0.7.0 [CHANGELOG](CHANGELOG.md) entry for the full wire diff.

Internal rework of how the hint is stored: a new `LoginHint = { kind: "email"; value: string }` lives on the `RegistrationClaimAttempt` (not the claim itself), so a corrected re-mint via `/agent/identity/claim` can carry a corrected hint without being locked to whatever the first attempt bound. The route classifies the wire string at the edge via `classifyLoginHint` and returns a new `invalid_login_hint` error if it doesn't look like an email. The user-facing wrong-account 403 on `/claim` is preserved — the signed-in user must match the current attempt's `login_hint` to complete the ceremony.

Discovery slim: `agent_auth.identity_assertion.assertion_types_supported` drops `"verified_email"` (ID-JAG only now); `identity_types_supported` gains `"service_auth"`. AUTH.md Step 2 narrows the cross-check guidance — only `identity_assertion` needs to consult discovery; `service_auth` and `anonymous` are send-and-fall-back on `*_not_enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)