### PR TITLE
Add agent-side client: core, MCP server, pi adapter

### DIFF
--- a/agent-clients/README.md
+++ b/agent-clients/README.md
@@ -1,0 +1,66 @@
+# authmd-agent-client
+
+The agent-side client for the [auth.md](../AUTH.md) agentic registration
+protocol. It collapses the full ceremony — discovery, registration, claim,
+jwt-bearer exchange, refresh — into a couple of deterministic tool calls,
+instead of asking the model to drive each HTTP request itself.
+
+Three pieces, one shared core:
+
+```
+src/core/   discovery → register → claim → exchange → refresh, credential store
+src/mcp/    stdio MCP server (Claude Desktop, Claude Code, Codex)
+src/pi/     pi extension adapter calling the core directly
+mcpb/       manifest for the Claude Desktop .mcpb bundle
+```
+
+## Tools
+
+All state is tenanted by `issuer` — one client holds independent
+registrations across many services.
+
+- **`authmd_authenticate(issuer, email?, resource?, id_jag?)`** — reuses
+  stored credentials when possible (cached access_token → live assertion →
+  refresh token), otherwise registers with the lightest applicable method:
+  `identity_assertion` when an ID-JAG is supplied, `service_auth` when an
+  email is given, `anonymous` otherwise. Returns ready credentials, or
+  `{ status: "claim_required", verification_uri }` when the user has to
+  confirm in a browser.
+- **`authmd_complete_claim(issuer, user_code)`** — finishes the ceremony
+  with the code the user read back from the claim page, persists the
+  post-claim identity (assertion + rotating refresh token), and exchanges
+  for an access token.
+- **`authmd_fetch(issuer, url, ...)`** — convenience wrapper that injects
+  the bearer token and transparently refreshes expired credentials.
+
+Claim tokens are held in memory only for the duration of the ceremony, per
+the spec. Identity assertions, refresh tokens, and access tokens persist in
+a `0600` JSON file at `~/.authmd/credentials.json` (override with
+`AUTHMD_STORE_PATH`). The store is behind a `CredentialStore` interface so
+an OS-keychain backend can be swapped in without touching the client.
+
+## Install
+
+MCP hosts (after `pnpm build`, or via npm once published):
+
+```sh
+# Claude Code
+claude mcp add authmd -- node <repo>/agent-clients/dist/mcp/server.js
+
+# Codex
+codex mcp add authmd -- node <repo>/agent-clients/dist/mcp/server.js
+```
+
+Claude Desktop: pack `manifest.json` + `dist/` with the `mcpb` CLI and
+double-click the resulting `.mcpb`.
+
+pi: the adapter in `src/pi/` default-exports an `activate(pi)` that
+registers the same three tools via `pi.registerTool()`.
+
+## Try it against the sample service
+
+```sh
+pnpm dev          # from the repo root: starts provider (4000) + service (8000)
+```
+
+Then point any of the tools at `http://localhost:8000` as the issuer.

--- a/agent-clients/README.md
+++ b/agent-clients/README.md
@@ -73,6 +73,17 @@ double-click the resulting `.mcpb`.
 pi: the adapter in `src/pi/` default-exports an `activate(pi)` that
 registers the same three tools via `pi.registerTool()`.
 
+Hermes ([hermes-agent](https://hermes-agent.nousresearch.com)): add the
+stdio server to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  authmd:
+    command: "node"
+    args: ["<repo>/agent-clients/dist/mcp/server.js"]
+    # or, once published: command: "npx", args: ["-y", "@workos/auth.md-client"]
+```
+
 ## Try it against the sample service
 
 ```sh

--- a/agent-clients/README.md
+++ b/agent-clients/README.md
@@ -39,6 +39,22 @@ a `0600` JSON file at `~/.authmd/credentials.json` (override with
 `AUTHMD_STORE_PATH`). The store is behind a `CredentialStore` interface so
 an OS-keychain backend can be swapped in without touching the client.
 
+## Trust model
+
+The client runs locally on the agent's machine, and tool inputs are trusted
+as the agent's own choices:
+
+- **`issuer` is trusted input.** Discovery fetches the issuer the caller
+  names, including `localhost` and private-network hosts (the sample
+  service runs on `localhost:8000`). If you embed the core where issuer
+  values can be influenced by untrusted prompts or content, enforce an
+  issuer allowlist in your adapter before calling the client.
+- **Tokens are agent credentials, not secrets from the agent.**
+  `authmd_authenticate` / `authmd_complete_claim` return the access token
+  plainly, and `authmd_fetch` sends it to the URL the caller supplies —
+  it's a convenience wrapper, not a security boundary. The credential file
+  exists for persistence/reuse across sessions, not to hide tokens.
+
 ## Install
 
 MCP hosts (after `pnpm build`, or via npm once published):

--- a/agent-clients/README.md
+++ b/agent-clients/README.md
@@ -1,4 +1,4 @@
-# authmd-agent-client
+# @workos/auth.md-client
 
 The agent-side client for the [auth.md](../AUTH.md) agentic registration
 protocol. It collapses the full ceremony — discovery, registration, claim,

--- a/agent-clients/mcpb/manifest.json
+++ b/agent-clients/mcpb/manifest.json
@@ -1,0 +1,38 @@
+{
+  "manifest_version": "0.3",
+  "name": "authmd-agent-client",
+  "display_name": "auth.md Agent Client",
+  "version": "0.1.0",
+  "description": "Agentic registration for services that support the auth.md protocol: authenticate, complete claim ceremonies, and make authenticated requests.",
+  "author": {
+    "name": "WorkOS",
+    "url": "https://github.com/workos/auth.md"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/workos/auth.md"
+  },
+  "license": "MIT",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/mcp/server.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/mcp/server.js"]
+    }
+  },
+  "tools": [
+    {
+      "name": "authmd_authenticate",
+      "description": "Authenticate to an auth.md-capable service; returns credentials or claim ceremony materials."
+    },
+    {
+      "name": "authmd_complete_claim",
+      "description": "Complete a claim ceremony with the code the user read back from the claim page."
+    },
+    {
+      "name": "authmd_fetch",
+      "description": "Make an authenticated HTTP request with automatic credential refresh."
+    }
+  ]
+}

--- a/agent-clients/mcpb/manifest.json
+++ b/agent-clients/mcpb/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "0.3",
-  "name": "authmd-agent-client",
+  "name": "auth.md-client",
   "display_name": "auth.md Agent Client",
   "version": "0.1.0",
   "description": "Agentic registration for services that support the auth.md protocol: authenticate, complete claim ceremonies, and make authenticated requests.",

--- a/agent-clients/package.json
+++ b/agent-clients/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p .",
     "typecheck": "tsc --noEmit",

--- a/agent-clients/package.json
+++ b/agent-clients/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "authmd-agent-client",
+  "name": "@workos/auth.md-client",
   "version": "0.1.0",
   "description": "Agent-side client for the auth.md agentic registration protocol: shared core, MCP stdio server, and pi extension adapter.",
   "license": "MIT",

--- a/agent-clients/package.json
+++ b/agent-clients/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "authmd-agent-client",
+  "version": "0.1.0",
+  "description": "Agent-side client for the auth.md agentic registration protocol: shared core, MCP stdio server, and pi extension adapter.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/core/index.js",
+  "types": "./dist/core/index.d.ts",
+  "exports": {
+    ".": "./dist/core/index.js",
+    "./mcp": "./dist/mcp/server.js",
+    "./pi": "./dist/pi/index.js"
+  },
+  "bin": {
+    "authmd-mcp": "./dist/mcp/server.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p .",
+    "typecheck": "tsc --noEmit",
+    "start:mcp": "node dist/mcp/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/agent-clients/src/core/client.ts
+++ b/agent-clients/src/core/client.ts
@@ -54,6 +54,8 @@ interface PendingClaim {
   verificationUri: string;
   attemptExpiresAt: string;
   email?: string;
+  /** RFC 8707 resource requested when the ceremony started. */
+  resource?: string;
 }
 
 /**
@@ -87,7 +89,7 @@ export class AgentAuthClient {
     if (opts.email && !opts.idJag && this.pendingClaims.has(issuer)) {
       const record = await this.store.get(issuer);
       if (record?.registration_type === "anonymous" && !record.claimed) {
-        return this.startClaimAttempt(issuer, opts.email);
+        return this.startClaimAttempt(issuer, opts.email, opts.resource);
       }
     }
 
@@ -144,7 +146,7 @@ export class AgentAuthClient {
     // The post-claim assertion and refresh token are one-shot: a persistence
     // failure must not prevent returning them to the caller.
     await this.persistBestEffort(base, record);
-    return this.exchange(base, record, resource);
+    return this.exchange(base, record, resource ?? pending.resource);
   }
 
   /**
@@ -328,14 +330,26 @@ export class AgentAuthClient {
     const body = (await readJson(res)) as RegistrationResponse;
 
     if (res.status === 401 && body.error === "interaction_required") {
-      return this.stashClaim(issuer, body, registrationType, opts.email);
+      return this.stashClaim(
+        issuer,
+        body,
+        registrationType,
+        opts.email,
+        opts.resource,
+      );
     }
     if (!res.ok) {
       throw protocolError(res.status, body);
     }
 
     if (registrationType === "service_auth") {
-      return this.stashClaim(issuer, body, registrationType, opts.email);
+      return this.stashClaim(
+        issuer,
+        body,
+        registrationType,
+        opts.email,
+        opts.resource,
+      );
     }
 
     // anonymous and clean-match identity_assertion return an identity now
@@ -365,6 +379,7 @@ export class AgentAuthClient {
         verificationUri: body.claim.attempt?.verification_uri ?? "",
         attemptExpiresAt:
           body.claim.attempt?.expires_at ?? body.claim.expires_at,
+        resource: opts.resource,
       });
     }
 
@@ -378,6 +393,7 @@ export class AgentAuthClient {
   async startClaimAttempt(
     issuer: string,
     email: string,
+    resource?: string,
   ): Promise<AuthenticateResult> {
     const base = normalizeIssuer(issuer);
     const pending = this.pendingClaims.get(base);
@@ -405,6 +421,7 @@ export class AgentAuthClient {
     pending.verificationUri = attempt.attempt.verification_uri;
     pending.attemptExpiresAt = attempt.attempt.expires_at;
     pending.email = email;
+    if (resource !== undefined) pending.resource = resource;
     return this.claimRequired(pending);
   }
 
@@ -413,6 +430,7 @@ export class AgentAuthClient {
     body: RegistrationResponse,
     registrationType: IdentityType,
     email?: string,
+    resource?: string,
   ): AuthenticateResult {
     if (!body.claim?.attempt) {
       throw new ProtocolError(
@@ -429,6 +447,7 @@ export class AgentAuthClient {
       verificationUri: body.claim.attempt.verification_uri,
       attemptExpiresAt: body.claim.attempt.expires_at,
       email,
+      resource,
     };
     this.pendingClaims.set(issuer, pending);
     return this.claimRequired(pending);

--- a/agent-clients/src/core/client.ts
+++ b/agent-clients/src/core/client.ts
@@ -1,0 +1,451 @@
+import { discover } from "./discovery.js";
+import { FileCredentialStore, normalizeIssuer } from "./store.js";
+import type { CredentialStore } from "./store.js";
+import type {
+  AuthenticateResult,
+  ClaimAttemptResponse,
+  ClaimCompleteResponse,
+  IdentityBlock,
+  IssuerRecord,
+  ProtocolErrorBody,
+  RegistrationResponse,
+  TokenResponse,
+} from "./types.js";
+import { ProtocolError } from "./types.js";
+
+const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+/** Clock skew allowance when judging stored expiry timestamps. */
+const EXPIRY_SLACK_MS = 30 * 1000;
+
+export interface AuthenticateOptions {
+  issuer: string;
+  /**
+   * The user's email (CIBA-style login_hint). Present → service_auth
+   * registration (claim ceremony required). Absent → anonymous.
+   */
+  email?: string;
+  /** RFC 8707 resource to pin the access_token to at the token endpoint. */
+  resource?: string;
+  /**
+   * A pre-minted ID-JAG JWT from the agent's identity provider. When given,
+   * registration uses identity_assertion instead of service_auth/anonymous.
+   */
+  idJag?: string;
+  /** Force a fresh registration even if stored credentials exist. */
+  forceReregister?: boolean;
+}
+
+export interface FetchOptions {
+  issuer: string;
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  resource?: string;
+}
+
+interface PendingClaim {
+  registrationId: string;
+  claimToken: string;
+  claimUrl: string;
+  verificationUri: string;
+  attemptExpiresAt: string;
+  email?: string;
+}
+
+/**
+ * Agent-side client for the auth.md agentic registration protocol. All
+ * state is tenanted by issuer: stored credentials, cached tokens, and
+ * in-flight claim ceremonies are independent per service.
+ *
+ * Claim tokens are held in memory only for the duration of the ceremony,
+ * per AUTH.md — they are never written to the credential store.
+ */
+export class AgentAuthClient {
+  private readonly store: CredentialStore;
+  private readonly pendingClaims = new Map<string, PendingClaim>();
+
+  constructor(store?: CredentialStore) {
+    this.store = store ?? new FileCredentialStore();
+  }
+
+  /**
+   * One-call authentication: reuse stored credentials when possible
+   * (cached access_token → live assertion → refresh token), otherwise
+   * register with the lightest applicable method. Returns ready
+   * credentials, or the claim ceremony materials when a human step is
+   * required.
+   */
+  async authenticate(opts: AuthenticateOptions): Promise<AuthenticateResult> {
+    const issuer = normalizeIssuer(opts.issuer);
+
+    if (!opts.forceReregister) {
+      const reused = await this.tryReuse(issuer, opts.resource);
+      if (reused) return reused;
+    }
+
+    return this.register(issuer, opts);
+  }
+
+  /**
+   * Complete an in-flight claim ceremony with the user_code the user read
+   * off the service's claim page, then exchange the post-claim assertion
+   * for an access_token.
+   */
+  async completeClaim(
+    issuer: string,
+    userCode: string,
+    resource?: string,
+  ): Promise<AuthenticateResult> {
+    const base = normalizeIssuer(issuer);
+    const pending = this.pendingClaims.get(base);
+    if (!pending) {
+      throw new ProtocolError(
+        "no_pending_claim",
+        `No claim ceremony in flight for ${base}. Call authenticate first.`,
+        400,
+      );
+    }
+
+    const metadata = await discover(base);
+    const res = await fetch(`${metadata.agent_auth.claim_endpoint}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        claim_token: pending.claimToken,
+        user_code: userCode,
+      }),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      throw protocolError(res.status, body);
+    }
+    const completed = body as ClaimCompleteResponse;
+    this.pendingClaims.delete(base);
+
+    const record: IssuerRecord = {
+      registration_id: completed.id,
+      registration_type: "service_auth",
+      claimed: true,
+      identity: completed.identity,
+    };
+    await this.store.set(base, record);
+    return this.exchange(base, record, resource);
+  }
+
+  /**
+   * Convenience: make an authenticated request to the service, injecting
+   * the bearer token and transparently refreshing expired credentials.
+   */
+  async fetchWithAuth(opts: FetchOptions): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const issuer = normalizeIssuer(opts.issuer);
+    const auth = await this.authenticate({ issuer, resource: opts.resource });
+    if (auth.status !== "ready") {
+      throw new ProtocolError(
+        "claim_required",
+        `A claim ceremony is required before calling the API. Hand the user: ${auth.verification_uri}`,
+        401,
+      );
+    }
+    const res = await fetch(opts.url, {
+      method: opts.method ?? "GET",
+      headers: {
+        ...opts.headers,
+        Authorization: `Bearer ${auth.access_token}`,
+      },
+      body: opts.body,
+    });
+    const headers: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return { status: res.status, headers, body: await res.text() };
+  }
+
+  /** Attempt reuse of stored credentials, cheapest first. */
+  private async tryReuse(
+    issuer: string,
+    resource?: string,
+  ): Promise<AuthenticateResult | undefined> {
+    const record = await this.store.get(issuer);
+    if (!record) return undefined;
+
+    if (record.access_token && isLive(record.access_token.expires_at)) {
+      return {
+        status: "ready",
+        access_token: record.access_token.value,
+        token_type: "Bearer",
+        expires_in: secondsUntil(record.access_token.expires_at),
+        scope: record.access_token.scope,
+        registration_id: record.registration_id,
+        registration_type: record.registration_type,
+        claimed: record.claimed,
+      };
+    }
+
+    if (record.identity && isLive(record.identity.expires_at)) {
+      return this.exchange(issuer, record, resource);
+    }
+
+    const refreshToken = record.identity?.refresh_token;
+    if (refreshToken && isLive(refreshToken.expires_at)) {
+      const refreshed = await this.refresh(issuer, record, refreshToken.value);
+      if (refreshed) return this.exchange(issuer, refreshed, resource);
+    }
+
+    return undefined;
+  }
+
+  /** Rotate the refresh token for a fresh identity assertion. */
+  private async refresh(
+    issuer: string,
+    record: IssuerRecord,
+    refreshToken: string,
+  ): Promise<IssuerRecord | undefined> {
+    const metadata = await discover(issuer);
+    const res = await fetch(metadata.agent_auth.identity_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "refresh", refresh_token: refreshToken }),
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as RegistrationResponse;
+    if (!body.identity) return undefined;
+    const updated: IssuerRecord = { ...record, identity: body.identity };
+    await this.store.set(issuer, updated);
+    return updated;
+  }
+
+  private async register(
+    issuer: string,
+    opts: AuthenticateOptions,
+  ): Promise<AuthenticateResult> {
+    const metadata = await discover(issuer);
+    const supported = metadata.agent_auth.identity_types_supported;
+
+    let requestBody: Record<string, string>;
+    let registrationType: IssuerRecord["registration_type"];
+    if (opts.idJag) {
+      requestBody = {
+        type: "identity_assertion",
+        assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
+        assertion: opts.idJag,
+      };
+      registrationType = "identity_assertion";
+    } else if (opts.email && supported.includes("service_auth")) {
+      requestBody = { type: "service_auth", login_hint: opts.email };
+      registrationType = "service_auth";
+    } else if (supported.includes("anonymous")) {
+      requestBody = { type: "anonymous" };
+      registrationType = "anonymous";
+    } else {
+      throw new ProtocolError(
+        "no_applicable_method",
+        `No applicable registration method: service advertises [${supported.join(", ")}]; provide an email for service_auth or an ID-JAG for identity_assertion`,
+        400,
+      );
+    }
+
+    const res = await fetch(metadata.agent_auth.identity_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    const body = (await res.json()) as RegistrationResponse;
+
+    if (res.status === 401 && body.error === "interaction_required") {
+      return this.stashClaim(issuer, body, opts.email);
+    }
+    if (!res.ok) {
+      throw protocolError(res.status, body);
+    }
+
+    if (registrationType === "service_auth") {
+      return this.stashClaim(issuer, body, opts.email);
+    }
+
+    // anonymous and clean-match identity_assertion return an identity now
+    if (!body.identity) {
+      throw new ProtocolError(
+        "unexpected_response",
+        "Registration response carried no identity block",
+        res.status,
+      );
+    }
+    const record: IssuerRecord = {
+      registration_id: body.id,
+      registration_type: registrationType,
+      claimed: registrationType === "identity_assertion",
+      identity: body.identity,
+    };
+    await this.store.set(issuer, record);
+
+    // Anonymous registrations may later be claimed; keep the claim token
+    // in memory so an email-bearing follow-up can start the ceremony.
+    if (registrationType === "anonymous" && body.claim) {
+      this.pendingClaims.set(issuer, {
+        registrationId: body.id,
+        claimToken: body.claim.token,
+        claimUrl: body.claim.url,
+        verificationUri: body.claim.attempt?.verification_uri ?? "",
+        attemptExpiresAt:
+          body.claim.attempt?.expires_at ?? body.claim.expires_at,
+      });
+    }
+
+    return this.exchange(issuer, record, opts.resource);
+  }
+
+  /**
+   * Start (or re-mint) a claim attempt for an in-flight ceremony —
+   * used for anonymous upgrades and expired user_code windows.
+   */
+  async startClaimAttempt(
+    issuer: string,
+    email: string,
+  ): Promise<AuthenticateResult> {
+    const base = normalizeIssuer(issuer);
+    const pending = this.pendingClaims.get(base);
+    if (!pending) {
+      throw new ProtocolError(
+        "no_pending_claim",
+        `No claimable registration in memory for ${base}. Re-register with authenticate.`,
+        400,
+      );
+    }
+    const res = await fetch(pending.claimUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "service_auth",
+        claim_token: pending.claimToken,
+        login_hint: email,
+      }),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      throw protocolError(res.status, body);
+    }
+    const attempt = body as ClaimAttemptResponse;
+    pending.verificationUri = attempt.attempt.verification_uri;
+    pending.attemptExpiresAt = attempt.attempt.expires_at;
+    pending.email = email;
+    return this.claimRequired(pending);
+  }
+
+  private stashClaim(
+    issuer: string,
+    body: RegistrationResponse,
+    email?: string,
+  ): AuthenticateResult {
+    if (!body.claim?.attempt) {
+      throw new ProtocolError(
+        "unexpected_response",
+        "Claim-required registration response carried no claim.attempt block",
+        200,
+      );
+    }
+    const pending: PendingClaim = {
+      registrationId: body.id,
+      claimToken: body.claim.token,
+      claimUrl: body.claim.url,
+      verificationUri: body.claim.attempt.verification_uri,
+      attemptExpiresAt: body.claim.attempt.expires_at,
+      email,
+    };
+    this.pendingClaims.set(issuer, pending);
+    return this.claimRequired(pending);
+  }
+
+  private claimRequired(pending: PendingClaim): AuthenticateResult {
+    return {
+      status: "claim_required",
+      registration_id: pending.registrationId,
+      verification_uri: pending.verificationUri,
+      attempt_expires_at: pending.attemptExpiresAt,
+      instructions:
+        "Ask the user to open the verification_uri and sign in. The page reveals a code; they read it back, and you finish with complete_claim.",
+    };
+  }
+
+  /** RFC 7523 jwt-bearer exchange of the stored assertion. */
+  private async exchange(
+    issuer: string,
+    record: IssuerRecord,
+    resource?: string,
+  ): Promise<AuthenticateResult> {
+    if (!record.identity) {
+      throw new ProtocolError(
+        "no_identity",
+        "No identity assertion on record to exchange",
+        400,
+      );
+    }
+    const metadata = await discover(issuer);
+    const params = new URLSearchParams({
+      grant_type: JWT_BEARER_GRANT,
+      assertion: record.identity.assertion,
+    });
+    if (resource) params.set("resource", resource);
+
+    const res = await fetch(metadata.token_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      throw protocolError(res.status, body);
+    }
+    const token = body as TokenResponse;
+
+    const updated: IssuerRecord = {
+      ...record,
+      access_token: {
+        value: token.access_token,
+        expires_at: new Date(
+          Date.now() + token.expires_in * 1000,
+        ).toISOString(),
+        scope: token.scope,
+      },
+    };
+    await this.store.set(issuer, updated);
+
+    return {
+      status: "ready",
+      access_token: token.access_token,
+      token_type: token.token_type,
+      expires_in: token.expires_in,
+      scope: token.scope,
+      registration_id: record.registration_id,
+      registration_type: record.registration_type,
+      claimed: record.claimed,
+    };
+  }
+}
+
+function protocolError(status: number, body: unknown): ProtocolError {
+  const parsed = body as ProtocolErrorBody;
+  return new ProtocolError(
+    parsed.error ?? "unknown_error",
+    parsed.message ?? parsed.error_description ?? `HTTP ${status}`,
+    status,
+    parsed,
+  );
+}
+
+function isLive(expiresAt: string): boolean {
+  return new Date(expiresAt).getTime() - EXPIRY_SLACK_MS > Date.now();
+}
+
+function secondsUntil(expiresAt: string): number {
+  return Math.max(
+    0,
+    Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000),
+  );
+}

--- a/agent-clients/src/core/client.ts
+++ b/agent-clients/src/core/client.ts
@@ -269,10 +269,17 @@ export class AgentAuthClient {
     // silently degrade to a fresh anonymous identity.
     if (!opts.email && !opts.idJag && !opts.forceReregister) {
       const existing = await this.store.get(issuer);
-      if (existing && existing.registration_type !== "anonymous") {
+      if (
+        existing &&
+        (existing.claimed || existing.registration_type !== "anonymous")
+      ) {
+        const hint =
+          existing.registration_type === "identity_assertion"
+            ? "ID-JAG"
+            : "email";
         throw new ProtocolError(
           "reauthentication_required",
-          `Stored ${existing.registration_type} credentials for ${issuer} have expired. Re-authenticate with the original ${existing.registration_type === "service_auth" ? "email" : "ID-JAG"}, or pass forceReregister to start over anonymously.`,
+          `Stored ${existing.claimed ? "claimed" : existing.registration_type} credentials for ${issuer} have expired. Re-authenticate with the original ${hint}, or pass forceReregister to start over anonymously.`,
           401,
         );
       }

--- a/agent-clients/src/core/client.ts
+++ b/agent-clients/src/core/client.ts
@@ -5,7 +5,7 @@ import type {
   AuthenticateResult,
   ClaimAttemptResponse,
   ClaimCompleteResponse,
-  IdentityBlock,
+  IdentityType,
   IssuerRecord,
   ProtocolErrorBody,
   RegistrationResponse,
@@ -14,6 +14,7 @@ import type {
 import { ProtocolError } from "./types.js";
 
 const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ID_JAG_ASSERTION_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
 
 /** Clock skew allowance when judging stored expiry timestamps. */
 const EXPIRY_SLACK_MS = 30 * 1000;
@@ -47,6 +48,7 @@ export interface FetchOptions {
 
 interface PendingClaim {
   registrationId: string;
+  registrationType: IdentityType;
   claimToken: string;
   claimUrl: string;
   verificationUri: string;
@@ -79,6 +81,15 @@ export class AgentAuthClient {
    */
   async authenticate(opts: AuthenticateOptions): Promise<AuthenticateResult> {
     const issuer = normalizeIssuer(opts.issuer);
+
+    // An email supplied against a live anonymous registration is an upgrade
+    // request: start the claim ceremony rather than reusing anonymous access.
+    if (opts.email && !opts.idJag && this.pendingClaims.has(issuer)) {
+      const record = await this.store.get(issuer);
+      if (record?.registration_type === "anonymous" && !record.claimed) {
+        return this.startClaimAttempt(issuer, opts.email);
+      }
+    }
 
     if (!opts.forceReregister) {
       const reused = await this.tryReuse(issuer, opts.resource);
@@ -117,7 +128,7 @@ export class AgentAuthClient {
         user_code: userCode,
       }),
     });
-    const body = await res.json();
+    const body = await readJson(res);
     if (!res.ok) {
       throw protocolError(res.status, body);
     }
@@ -126,11 +137,13 @@ export class AgentAuthClient {
 
     const record: IssuerRecord = {
       registration_id: completed.id,
-      registration_type: "service_auth",
+      registration_type: pending.registrationType,
       claimed: true,
       identity: completed.identity,
     };
-    await this.store.set(base, record);
+    // The post-claim assertion and refresh token are one-shot: a persistence
+    // failure must not prevent returning them to the caller.
+    await this.persistBestEffort(base, record);
     return this.exchange(base, record, resource);
   }
 
@@ -152,14 +165,33 @@ export class AgentAuthClient {
         401,
       );
     }
-    const res = await fetch(opts.url, {
-      method: opts.method ?? "GET",
-      headers: {
-        ...opts.headers,
-        Authorization: `Bearer ${auth.access_token}`,
-      },
-      body: opts.body,
-    });
+    const doFetch = (token: string) =>
+      fetch(opts.url, {
+        method: opts.method ?? "GET",
+        headers: {
+          ...opts.headers,
+          Authorization: `Bearer ${token}`,
+        },
+        body: opts.body,
+      });
+    let res = await doFetch(auth.access_token);
+
+    // A 401 against a cached token usually means it was revoked server-side:
+    // drop the cache and retry once with a freshly exchanged token.
+    if (res.status === 401) {
+      const record = await this.store.get(issuer);
+      if (record?.access_token) {
+        await this.store.set(issuer, { ...record, access_token: undefined });
+        const retried = await this.authenticate({
+          issuer,
+          resource: opts.resource,
+        });
+        if (retried.status === "ready") {
+          res = await doFetch(retried.access_token);
+        }
+      }
+    }
+
     const headers: Record<string, string> = {};
     res.headers.forEach((value, key) => {
       headers[key] = value;
@@ -175,7 +207,11 @@ export class AgentAuthClient {
     const record = await this.store.get(issuer);
     if (!record) return undefined;
 
-    if (record.access_token && isLive(record.access_token.expires_at)) {
+    if (
+      record.access_token &&
+      isLive(record.access_token.expires_at) &&
+      record.access_token.resource === resource
+    ) {
       return {
         status: "ready",
         access_token: record.access_token.value,
@@ -214,10 +250,11 @@ export class AgentAuthClient {
       body: JSON.stringify({ type: "refresh", refresh_token: refreshToken }),
     });
     if (!res.ok) return undefined;
-    const body = (await res.json()) as RegistrationResponse;
+    const body = (await readJson(res)) as RegistrationResponse;
     if (!body.identity) return undefined;
+    // The rotated refresh token is one-shot; don't lose it to a store failure.
     const updated: IssuerRecord = { ...record, identity: body.identity };
-    await this.store.set(issuer, updated);
+    await this.persistBestEffort(issuer, updated);
     return updated;
   }
 
@@ -228,12 +265,37 @@ export class AgentAuthClient {
     const metadata = await discover(issuer);
     const supported = metadata.agent_auth.identity_types_supported;
 
+    // A user-bound registration whose credentials have all expired must not
+    // silently degrade to a fresh anonymous identity.
+    if (!opts.email && !opts.idJag && !opts.forceReregister) {
+      const existing = await this.store.get(issuer);
+      if (existing && existing.registration_type !== "anonymous") {
+        throw new ProtocolError(
+          "reauthentication_required",
+          `Stored ${existing.registration_type} credentials for ${issuer} have expired. Re-authenticate with the original ${existing.registration_type === "service_auth" ? "email" : "ID-JAG"}, or pass forceReregister to start over anonymously.`,
+          401,
+        );
+      }
+    }
+
     let requestBody: Record<string, string>;
     let registrationType: IssuerRecord["registration_type"];
     if (opts.idJag) {
+      const assertionTypes =
+        metadata.agent_auth.identity_assertion?.assertion_types_supported ?? [];
+      if (
+        !supported.includes("identity_assertion") ||
+        !assertionTypes.includes(ID_JAG_ASSERTION_TYPE)
+      ) {
+        throw new ProtocolError(
+          "unsupported_identity_type",
+          `Service does not advertise identity_assertion with ${ID_JAG_ASSERTION_TYPE} (supported: [${supported.join(", ")}])`,
+          400,
+        );
+      }
       requestBody = {
         type: "identity_assertion",
-        assertion_type: "urn:ietf:params:oauth:token-type:id-jag",
+        assertion_type: ID_JAG_ASSERTION_TYPE,
         assertion: opts.idJag,
       };
       registrationType = "identity_assertion";
@@ -256,17 +318,17 @@ export class AgentAuthClient {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(requestBody),
     });
-    const body = (await res.json()) as RegistrationResponse;
+    const body = (await readJson(res)) as RegistrationResponse;
 
     if (res.status === 401 && body.error === "interaction_required") {
-      return this.stashClaim(issuer, body, opts.email);
+      return this.stashClaim(issuer, body, registrationType, opts.email);
     }
     if (!res.ok) {
       throw protocolError(res.status, body);
     }
 
     if (registrationType === "service_auth") {
-      return this.stashClaim(issuer, body, opts.email);
+      return this.stashClaim(issuer, body, registrationType, opts.email);
     }
 
     // anonymous and clean-match identity_assertion return an identity now
@@ -290,6 +352,7 @@ export class AgentAuthClient {
     if (registrationType === "anonymous" && body.claim) {
       this.pendingClaims.set(issuer, {
         registrationId: body.id,
+        registrationType,
         claimToken: body.claim.token,
         claimUrl: body.claim.url,
         verificationUri: body.claim.attempt?.verification_uri ?? "",
@@ -327,7 +390,7 @@ export class AgentAuthClient {
         login_hint: email,
       }),
     });
-    const body = await res.json();
+    const body = await readJson(res);
     if (!res.ok) {
       throw protocolError(res.status, body);
     }
@@ -341,6 +404,7 @@ export class AgentAuthClient {
   private stashClaim(
     issuer: string,
     body: RegistrationResponse,
+    registrationType: IdentityType,
     email?: string,
   ): AuthenticateResult {
     if (!body.claim?.attempt) {
@@ -352,6 +416,7 @@ export class AgentAuthClient {
     }
     const pending: PendingClaim = {
       registrationId: body.id,
+      registrationType,
       claimToken: body.claim.token,
       claimUrl: body.claim.url,
       verificationUri: body.claim.attempt.verification_uri,
@@ -398,7 +463,7 @@ export class AgentAuthClient {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: params.toString(),
     });
-    const body = await res.json();
+    const body = await readJson(res);
     if (!res.ok) {
       throw protocolError(res.status, body);
     }
@@ -412,9 +477,10 @@ export class AgentAuthClient {
           Date.now() + token.expires_in * 1000,
         ).toISOString(),
         scope: token.scope,
+        resource,
       },
     };
-    await this.store.set(issuer, updated);
+    await this.persistBestEffort(issuer, updated);
 
     return {
       status: "ready",
@@ -426,6 +492,38 @@ export class AgentAuthClient {
       registration_type: record.registration_type,
       claimed: record.claimed,
     };
+  }
+
+  /**
+   * Persist without letting a storage failure destroy one-shot credentials
+   * that the caller still needs returned.
+   */
+  private async persistBestEffort(
+    issuer: string,
+    record: IssuerRecord,
+  ): Promise<void> {
+    try {
+      await this.store.set(issuer, record);
+    } catch (err) {
+      console.error(
+        `authmd: failed to persist credentials for ${issuer}:`,
+        err,
+      );
+    }
+  }
+}
+
+/** Parse a JSON body, surfacing the HTTP status when the body is not JSON. */
+async function readJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new ProtocolError(
+      "invalid_response",
+      `Non-JSON response (HTTP ${res.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+      res.status,
+    );
   }
 }
 

--- a/agent-clients/src/core/discovery.ts
+++ b/agent-clients/src/core/discovery.ts
@@ -1,0 +1,44 @@
+import type { AuthorizationServerMetadata } from "./types.js";
+import { ProtocolError } from "./types.js";
+import { normalizeIssuer } from "./store.js";
+
+const METADATA_PATH = "/.well-known/oauth-authorization-server";
+
+const cache = new Map<
+  string,
+  { metadata: AuthorizationServerMetadata; fetchedAt: number }
+>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Fetch (and cache) the authorization server metadata for an issuer,
+ * including the `agent_auth` bootstrap block.
+ */
+export async function discover(
+  issuer: string,
+): Promise<AuthorizationServerMetadata> {
+  const base = normalizeIssuer(issuer);
+  const cached = cache.get(base);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.metadata;
+  }
+
+  const res = await fetch(`${base}${METADATA_PATH}`);
+  if (!res.ok) {
+    throw new ProtocolError(
+      "discovery_failed",
+      `GET ${base}${METADATA_PATH} returned ${res.status}`,
+      res.status,
+    );
+  }
+  const metadata = (await res.json()) as AuthorizationServerMetadata;
+  if (!metadata.agent_auth?.identity_endpoint) {
+    throw new ProtocolError(
+      "agent_auth_unsupported",
+      `${base} does not advertise an agent_auth block; agentic registration is not supported`,
+      200,
+    );
+  }
+  cache.set(base, { metadata, fetchedAt: Date.now() });
+  return metadata;
+}

--- a/agent-clients/src/core/index.ts
+++ b/agent-clients/src/core/index.ts
@@ -1,0 +1,6 @@
+export { AgentAuthClient } from "./client.js";
+export type { AuthenticateOptions, FetchOptions } from "./client.js";
+export { discover } from "./discovery.js";
+export { FileCredentialStore, normalizeIssuer } from "./store.js";
+export type { CredentialStore } from "./store.js";
+export * from "./types.js";

--- a/agent-clients/src/core/store.ts
+++ b/agent-clients/src/core/store.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IssuerRecord } from "./types.js";
+
+/**
+ * Per-issuer credential store. Everything is tenanted by the issuer URL, so
+ * one client can hold independent registrations across many services.
+ *
+ * Default backend is a 0600 JSON file under ~/.authmd/. The interface is
+ * pluggable so hosts can swap in an OS-keychain backend without touching
+ * the client.
+ */
+export interface CredentialStore {
+  get(issuer: string): Promise<IssuerRecord | undefined>;
+  set(issuer: string, record: IssuerRecord): Promise<void>;
+  delete(issuer: string): Promise<void>;
+}
+
+interface StoreFile {
+  version: 1;
+  issuers: Record<string, IssuerRecord>;
+}
+
+export class FileCredentialStore implements CredentialStore {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath =
+      filePath ??
+      process.env.AUTHMD_STORE_PATH ??
+      path.join(os.homedir(), ".authmd", "credentials.json");
+  }
+
+  private async read(): Promise<StoreFile> {
+    try {
+      const raw = await fs.readFile(this.filePath, "utf8");
+      return JSON.parse(raw) as StoreFile;
+    } catch {
+      return { version: 1, issuers: {} };
+    }
+  }
+
+  private async write(data: StoreFile): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), {
+      recursive: true,
+      mode: 0o700,
+    });
+    const tmp = `${this.filePath}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    await fs.rename(tmp, this.filePath);
+  }
+
+  async get(issuer: string): Promise<IssuerRecord | undefined> {
+    const data = await this.read();
+    return data.issuers[normalizeIssuer(issuer)];
+  }
+
+  async set(issuer: string, record: IssuerRecord): Promise<void> {
+    const data = await this.read();
+    data.issuers[normalizeIssuer(issuer)] = record;
+    await this.write(data);
+  }
+
+  async delete(issuer: string): Promise<void> {
+    const data = await this.read();
+    delete data.issuers[normalizeIssuer(issuer)];
+    await this.write(data);
+  }
+}
+
+export function normalizeIssuer(issuer: string): string {
+  return issuer.replace(/\/+$/, "");
+}

--- a/agent-clients/src/core/store.ts
+++ b/agent-clients/src/core/store.ts
@@ -65,9 +65,17 @@ export class FileCredentialStore implements CredentialStore {
     for (;;) {
       try {
         const handle = await fs.open(lockPath, "wx", 0o600);
+        // Heartbeat: keep the lock's mtime fresh while held so other
+        // processes don't mistake a live (but slow) holder for a stale lock.
+        const heartbeat = setInterval(() => {
+          const now = new Date();
+          void fs.utimes(lockPath, now, now).catch(() => undefined);
+        }, LOCK_STALE_MS / 3);
+        heartbeat.unref();
         try {
           return await op();
         } finally {
+          clearInterval(heartbeat);
           await handle.close();
           await fs.unlink(lockPath).catch(() => undefined);
         }

--- a/agent-clients/src/core/store.ts
+++ b/agent-clients/src/core/store.ts
@@ -18,6 +18,14 @@ export interface CredentialStore {
   delete(issuer: string): Promise<void>;
 }
 
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 10 * 1000;
+const LOCK_STALE_MS = 30 * 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 interface StoreFile {
   version: 1;
   issuers: Record<string, IssuerRecord>;
@@ -39,6 +47,45 @@ export class FileCredentialStore implements CredentialStore {
     const next = this.queue.then(op, op);
     this.queue = next.catch(() => undefined);
     return next;
+  }
+
+  /**
+   * Cross-process advisory lock: an exclusively created lockfile guards the
+   * read-modify-write cycle so concurrent host processes (e.g. Claude and
+   * Codex sharing ~/.authmd) can't discard each other's updates. Locks older
+   * than LOCK_STALE_MS are treated as abandoned by a crashed process.
+   */
+  private async withLock<T>(op: () => Promise<T>): Promise<T> {
+    const lockPath = `${this.filePath}.lock`;
+    await fs.mkdir(path.dirname(this.filePath), {
+      recursive: true,
+      mode: 0o700,
+    });
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    for (;;) {
+      try {
+        const handle = await fs.open(lockPath, "wx", 0o600);
+        try {
+          return await op();
+        } finally {
+          await handle.close();
+          await fs.unlink(lockPath).catch(() => undefined);
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+        const stat = await fs.stat(lockPath).catch(() => undefined);
+        if (stat && Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          await fs.unlink(lockPath).catch(() => undefined);
+          continue;
+        }
+        if (Date.now() > deadline) {
+          throw new Error(
+            `Timed out waiting for credential store lock at ${lockPath}`,
+          );
+        }
+        await sleep(LOCK_RETRY_MS);
+      }
+    }
   }
 
   private async read(): Promise<StoreFile> {
@@ -66,19 +113,23 @@ export class FileCredentialStore implements CredentialStore {
   }
 
   async set(issuer: string, record: IssuerRecord): Promise<void> {
-    await this.enqueue(async () => {
-      const data = await this.read();
-      data.issuers[normalizeIssuer(issuer)] = record;
-      await this.write(data);
-    });
+    await this.enqueue(() =>
+      this.withLock(async () => {
+        const data = await this.read();
+        data.issuers[normalizeIssuer(issuer)] = record;
+        await this.write(data);
+      }),
+    );
   }
 
   async delete(issuer: string): Promise<void> {
-    await this.enqueue(async () => {
-      const data = await this.read();
-      delete data.issuers[normalizeIssuer(issuer)];
-      await this.write(data);
-    });
+    await this.enqueue(() =>
+      this.withLock(async () => {
+        const data = await this.read();
+        delete data.issuers[normalizeIssuer(issuer)];
+        await this.write(data);
+      }),
+    );
   }
 }
 

--- a/agent-clients/src/core/store.ts
+++ b/agent-clients/src/core/store.ts
@@ -65,6 +65,7 @@ export class FileCredentialStore implements CredentialStore {
     for (;;) {
       try {
         const handle = await fs.open(lockPath, "wx", 0o600);
+        const ownIno = (await handle.stat()).ino;
         // Heartbeat: keep the lock's mtime fresh while held so other
         // processes don't mistake a live (but slow) holder for a stale lock.
         const heartbeat = setInterval(() => {
@@ -77,7 +78,13 @@ export class FileCredentialStore implements CredentialStore {
         } finally {
           clearInterval(heartbeat);
           await handle.close();
-          await fs.unlink(lockPath).catch(() => undefined);
+          // Only remove the lock if it is still ours: a holder that was
+          // suspended past LOCK_STALE_MS may have had its lock replaced,
+          // and must not unlink the new holder's lockfile.
+          const current = await fs.stat(lockPath).catch(() => undefined);
+          if (current?.ino === ownIno) {
+            await fs.unlink(lockPath).catch(() => undefined);
+          }
         }
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;

--- a/agent-clients/src/core/store.ts
+++ b/agent-clients/src/core/store.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -24,12 +25,20 @@ interface StoreFile {
 
 export class FileCredentialStore implements CredentialStore {
   private readonly filePath: string;
+  /** Serializes read-modify-write cycles within this process. */
+  private queue: Promise<unknown> = Promise.resolve();
 
   constructor(filePath?: string) {
     this.filePath =
       filePath ??
       process.env.AUTHMD_STORE_PATH ??
       path.join(os.homedir(), ".authmd", "credentials.json");
+  }
+
+  private enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(op, op);
+    this.queue = next.catch(() => undefined);
+    return next;
   }
 
   private async read(): Promise<StoreFile> {
@@ -46,7 +55,7 @@ export class FileCredentialStore implements CredentialStore {
       recursive: true,
       mode: 0o700,
     });
-    const tmp = `${this.filePath}.tmp`;
+    const tmp = `${this.filePath}.${crypto.randomBytes(6).toString("hex")}.tmp`;
     await fs.writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
     await fs.rename(tmp, this.filePath);
   }
@@ -57,15 +66,19 @@ export class FileCredentialStore implements CredentialStore {
   }
 
   async set(issuer: string, record: IssuerRecord): Promise<void> {
-    const data = await this.read();
-    data.issuers[normalizeIssuer(issuer)] = record;
-    await this.write(data);
+    await this.enqueue(async () => {
+      const data = await this.read();
+      data.issuers[normalizeIssuer(issuer)] = record;
+      await this.write(data);
+    });
   }
 
   async delete(issuer: string): Promise<void> {
-    const data = await this.read();
-    delete data.issuers[normalizeIssuer(issuer)];
-    await this.write(data);
+    await this.enqueue(async () => {
+      const data = await this.read();
+      delete data.issuers[normalizeIssuer(issuer)];
+      await this.write(data);
+    });
   }
 }
 

--- a/agent-clients/src/core/types.ts
+++ b/agent-clients/src/core/types.ts
@@ -95,6 +95,8 @@ export interface IssuerRecord {
     value: string;
     expires_at: string;
     scope?: string;
+    /** RFC 8707 resource the token was minted for, when one was requested. */
+    resource?: string;
   };
 }
 

--- a/agent-clients/src/core/types.ts
+++ b/agent-clients/src/core/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Wire types for the auth.md agentic registration protocol (v0.7.0),
+ * mirroring AUTH.md and agent-services' response shapes.
+ */
+
+export type IdentityType = "anonymous" | "identity_assertion" | "service_auth";
+
+export interface AgentAuthMetadata {
+  skill?: string;
+  identity_endpoint: string;
+  claim_endpoint: string;
+  events_endpoint?: string;
+  identity_types_supported: IdentityType[];
+  identity_assertion?: { assertion_types_supported: string[] };
+  events_supported?: string[];
+}
+
+export interface AuthorizationServerMetadata {
+  issuer: string;
+  token_endpoint: string;
+  revocation_endpoint?: string;
+  grant_types_supported?: string[];
+  resource?: string;
+  scopes_supported?: string[];
+  agent_auth: AgentAuthMetadata;
+}
+
+export interface RefreshTokenBlock {
+  value: string;
+  expires_at: string;
+}
+
+export interface IdentityBlock {
+  assertion: string;
+  expires_at: string;
+  refresh_token?: RefreshTokenBlock;
+}
+
+export interface ClaimAttemptBlock {
+  verification_uri: string;
+  expires_at: string;
+}
+
+export interface ClaimBlock {
+  token: string;
+  expires_at: string;
+  url: string;
+  attempt?: ClaimAttemptBlock;
+}
+
+export interface RegistrationResponse {
+  id: string;
+  type: IdentityType | "refresh";
+  identity?: IdentityBlock;
+  scopes?: string[] | { pre_claim?: string[]; post_claim?: string[] };
+  claim?: ClaimBlock;
+  /** Present on 401 interaction_required / login_required bodies. */
+  error?: string;
+  error_description?: string;
+}
+
+export interface ClaimAttemptResponse {
+  id: string;
+  type: "service_auth";
+  attempt: ClaimAttemptBlock;
+}
+
+export interface ClaimCompleteResponse {
+  id: string;
+  status: string;
+  identity: IdentityBlock;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+}
+
+export interface ProtocolErrorBody {
+  error: string;
+  message?: string;
+  error_description?: string;
+  max_age?: number;
+}
+
+/** Persisted per-issuer credential record (see store.ts). */
+export interface IssuerRecord {
+  registration_id: string;
+  registration_type: IdentityType;
+  claimed: boolean;
+  identity?: IdentityBlock;
+  access_token?: {
+    value: string;
+    expires_at: string;
+    scope?: string;
+  };
+}
+
+export type AuthenticateResult =
+  | {
+      status: "ready";
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+      scope?: string;
+      registration_id: string;
+      registration_type: IdentityType;
+      claimed: boolean;
+    }
+  | {
+      status: "claim_required";
+      registration_id: string;
+      verification_uri: string;
+      attempt_expires_at: string;
+      instructions: string;
+    };
+
+export class ProtocolError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+    readonly body?: ProtocolErrorBody,
+  ) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}

--- a/agent-clients/src/mcp/server.ts
+++ b/agent-clients/src/mcp/server.ts
@@ -14,7 +14,7 @@ import { ProtocolError } from "../core/types.js";
 const client = new AgentAuthClient();
 
 const server = new McpServer({
-  name: "authmd-agent-client",
+  name: "@workos/auth.md-client",
   version: "0.1.0",
 });
 

--- a/agent-clients/src/mcp/server.ts
+++ b/agent-clients/src/mcp/server.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { AgentAuthClient } from "../core/client.js";
+import { ProtocolError } from "../core/types.js";
+
+/**
+ * MCP stdio server exposing the auth.md registration flow as three tools:
+ * authmd_authenticate, authmd_complete_claim, authmd_fetch. Works in
+ * Claude Desktop (via the .mcpb bundle), Claude Code (`claude mcp add`),
+ * and Codex (`codex mcp add`).
+ */
+const client = new AgentAuthClient();
+
+const server = new McpServer({
+  name: "authmd-agent-client",
+  version: "0.1.0",
+});
+
+function jsonResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function errorResult(error: unknown) {
+  if (error instanceof ProtocolError) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            { error: error.code, message: error.message, status: error.status },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: String(error) }],
+  };
+}
+
+server.tool(
+  "authmd_authenticate",
+  "Authenticate to a service that supports auth.md agentic registration. Reuses stored credentials for the issuer when possible; otherwise registers (service_auth when an email is given, anonymous otherwise, or identity_assertion when an ID-JAG is supplied) and exchanges for an access token. Returns ready credentials, or claim ceremony materials when the user must confirm in a browser.",
+  {
+    issuer: z.string().describe("Authorization server issuer URL"),
+    email: z
+      .string()
+      .optional()
+      .describe("The user's email (login_hint) for service_auth registration"),
+    resource: z
+      .string()
+      .optional()
+      .describe("RFC 8707 resource URI to pin the access token to"),
+    id_jag: z
+      .string()
+      .optional()
+      .describe("Pre-minted ID-JAG JWT for identity_assertion registration"),
+    force_reregister: z
+      .boolean()
+      .optional()
+      .describe("Ignore stored credentials and register fresh"),
+  },
+  async ({ issuer, email, resource, id_jag, force_reregister }) => {
+    try {
+      const result = await client.authenticate({
+        issuer,
+        email,
+        resource,
+        idJag: id_jag,
+        forceReregister: force_reregister,
+      });
+      return jsonResult(result);
+    } catch (error) {
+      return errorResult(error);
+    }
+  },
+);
+
+server.tool(
+  "authmd_complete_claim",
+  "Complete an in-flight claim ceremony. Call after the user opened the verification_uri, signed in, and read back the code shown on the page. Returns ready credentials.",
+  {
+    issuer: z.string().describe("Authorization server issuer URL"),
+    user_code: z
+      .string()
+      .describe("The code the user read back from the claim page"),
+    resource: z
+      .string()
+      .optional()
+      .describe("RFC 8707 resource URI to pin the access token to"),
+  },
+  async ({ issuer, user_code, resource }) => {
+    try {
+      const result = await client.completeClaim(issuer, user_code, resource);
+      return jsonResult(result);
+    } catch (error) {
+      return errorResult(error);
+    }
+  },
+);
+
+server.tool(
+  "authmd_fetch",
+  "Make an authenticated HTTP request to a service registered via authmd_authenticate. Injects the bearer token and transparently refreshes expired credentials.",
+  {
+    issuer: z.string().describe("Authorization server issuer URL"),
+    url: z.string().describe("Absolute URL to request"),
+    method: z.string().optional().describe("HTTP method (default GET)"),
+    headers: z.record(z.string()).optional().describe("Extra request headers"),
+    body: z.string().optional().describe("Request body"),
+    resource: z
+      .string()
+      .optional()
+      .describe("RFC 8707 resource URI to pin the access token to"),
+  },
+  async ({ issuer, url, method, headers, body, resource }) => {
+    try {
+      const result = await client.fetchWithAuth({
+        issuer,
+        url,
+        method,
+        headers,
+        body,
+        resource,
+      });
+      return jsonResult(result);
+    } catch (error) {
+      return errorResult(error);
+    }
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/agent-clients/src/pi/index.ts
+++ b/agent-clients/src/pi/index.ts
@@ -1,0 +1,157 @@
+import { AgentAuthClient } from "../core/client.js";
+import { ProtocolError } from "../core/types.js";
+
+/**
+ * pi extension adapter. pi extensions are TypeScript modules that register
+ * tools directly, so this calls the shared core without an MCP hop.
+ *
+ * Structural interface for the slice of pi's extension API we use, so the
+ * adapter compiles without a dependency on pi itself.
+ */
+interface PiToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+interface PiLike {
+  registerTool(tool: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    execute(args: Record<string, unknown>): Promise<PiToolResult>;
+  }): void;
+}
+
+function json(value: unknown): PiToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+function failure(error: unknown): PiToolResult {
+  const payload =
+    error instanceof ProtocolError
+      ? { error: error.code, message: error.message, status: error.status }
+      : { error: "unknown_error", message: String(error) };
+  return {
+    isError: true,
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+  };
+}
+
+function str(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export default function activate(pi: PiLike): void {
+  const client = new AgentAuthClient();
+
+  pi.registerTool({
+    name: "authmd_authenticate",
+    description:
+      "Authenticate to a service that supports auth.md agentic registration. Reuses stored credentials for the issuer when possible; otherwise registers and exchanges for an access token. Returns ready credentials, or claim ceremony materials when the user must confirm in a browser.",
+    parameters: {
+      type: "object",
+      properties: {
+        issuer: {
+          type: "string",
+          description: "Authorization server issuer URL",
+        },
+        email: {
+          type: "string",
+          description: "The user's email (login_hint) for service_auth",
+        },
+        resource: { type: "string", description: "RFC 8707 resource URI" },
+        id_jag: { type: "string", description: "Pre-minted ID-JAG JWT" },
+      },
+      required: ["issuer"],
+    },
+    async execute(args) {
+      try {
+        const issuer = str(args, "issuer");
+        if (!issuer) return failure(new Error("issuer is required"));
+        return json(
+          await client.authenticate({
+            issuer,
+            email: str(args, "email"),
+            resource: str(args, "resource"),
+            idJag: str(args, "id_jag"),
+          }),
+        );
+      } catch (error) {
+        return failure(error);
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "authmd_complete_claim",
+    description:
+      "Complete an in-flight claim ceremony with the code the user read back from the service's claim page.",
+    parameters: {
+      type: "object",
+      properties: {
+        issuer: {
+          type: "string",
+          description: "Authorization server issuer URL",
+        },
+        user_code: { type: "string", description: "Code the user read back" },
+        resource: { type: "string", description: "RFC 8707 resource URI" },
+      },
+      required: ["issuer", "user_code"],
+    },
+    async execute(args) {
+      try {
+        const issuer = str(args, "issuer");
+        const userCode = str(args, "user_code");
+        if (!issuer || !userCode) {
+          return failure(new Error("issuer and user_code are required"));
+        }
+        return json(
+          await client.completeClaim(issuer, userCode, str(args, "resource")),
+        );
+      } catch (error) {
+        return failure(error);
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "authmd_fetch",
+    description:
+      "Make an authenticated HTTP request to a service registered via authmd_authenticate. Injects the bearer token and refreshes expired credentials.",
+    parameters: {
+      type: "object",
+      properties: {
+        issuer: {
+          type: "string",
+          description: "Authorization server issuer URL",
+        },
+        url: { type: "string", description: "Absolute URL to request" },
+        method: { type: "string", description: "HTTP method (default GET)" },
+        body: { type: "string", description: "Request body" },
+        resource: { type: "string", description: "RFC 8707 resource URI" },
+      },
+      required: ["issuer", "url"],
+    },
+    async execute(args) {
+      try {
+        const issuer = str(args, "issuer");
+        const url = str(args, "url");
+        if (!issuer || !url) {
+          return failure(new Error("issuer and url are required"));
+        }
+        return json(
+          await client.fetchWithAuth({
+            issuer,
+            url,
+            method: str(args, "method"),
+            body: str(args, "body"),
+            resource: str(args, "resource"),
+          }),
+        );
+      } catch (error) {
+        return failure(error);
+      }
+    },
+  });
+}

--- a/agent-clients/src/pi/index.ts
+++ b/agent-clients/src/pi/index.ts
@@ -42,6 +42,19 @@ function str(args: Record<string, unknown>, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function strRecord(
+  args: Record<string, unknown>,
+  key: string,
+): Record<string, string> | undefined {
+  const value = args[key];
+  if (typeof value !== "object" || value === null) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
 export default function activate(pi: PiLike): void {
   const client = new AgentAuthClient();
 
@@ -128,6 +141,11 @@ export default function activate(pi: PiLike): void {
         },
         url: { type: "string", description: "Absolute URL to request" },
         method: { type: "string", description: "HTTP method (default GET)" },
+        headers: {
+          type: "object",
+          description: "Extra request headers",
+          additionalProperties: { type: "string" },
+        },
         body: { type: "string", description: "Request body" },
         resource: { type: "string", description: "RFC 8707 resource URI" },
       },
@@ -145,6 +163,7 @@ export default function activate(pi: PiLike): void {
             issuer,
             url,
             method: str(args, "method"),
+            headers: strRecord(args, "headers"),
             body: str(args, "body"),
             resource: str(args, "resource"),
           }),

--- a/agent-clients/tsconfig.json
+++ b/agent-clients/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,25 @@ importers:
         specifier: ^3.3.3
         version: 3.8.3
 
+  agent-clients:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.30.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   agent-providers:
     dependencies:
       express:
@@ -325,6 +344,46 @@ packages:
     dev: true
     optional: true
 
+  /@hono/node-server@2.1.1(hono@4.13.5):
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.13.5
+    dev: false
+
+  /@modelcontextprotocol/sdk@1.30.0(zod@3.25.76):
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@types/body-parser@1.19.6:
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
     dependencies:
@@ -419,6 +478,34 @@ packages:
       negotiator: 0.6.3
     dev: false
 
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+    dev: false
+
+  /ajv-formats@3.0.1(ajv@8.20.0):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.20.0
+    dev: false
+
+  /ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -451,6 +538,23 @@ packages:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -524,13 +628,28 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
     dev: false
 
+  /content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+    dev: false
+
   /cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+    dev: false
+
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
     dev: false
 
   /cookie@0.7.2:
@@ -546,6 +665,15 @@ packages:
       vary: 1.1.2
     dev: false
 
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: false
+
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -555,6 +683,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
+    dev: false
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
     dev: false
 
   /depd@2.0.0:
@@ -654,6 +794,31 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.1.1
+    dev: false
+
+  /express-rate-limit@8.7.0(express@5.2.1):
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /express-session@1.19.0:
     resolution: {integrity: sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==}
     engines: {node: '>= 0.8.0'}
@@ -709,6 +874,50 @@ packages:
       - supports-color
     dev: false
 
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
+  /fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+    dev: false
+
   /finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
@@ -724,6 +933,20 @@ packages:
       - supports-color
     dev: false
 
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -732,6 +955,11 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /fsevents@2.3.3:
@@ -803,6 +1031,11 @@ packages:
       function-bind: 1.1.2
     dev: false
 
+  /hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
   /http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -821,8 +1054,20 @@ packages:
       safer-buffer: 2.1.2
     dev: false
 
+  /iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
     dev: false
 
   /ipaddr.js@1.9.1:
@@ -835,8 +1080,28 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
+
+  /isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: false
+
   /jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+    dev: false
+
+  /jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
+    dev: false
+
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
+
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
     dev: false
 
   /math-intrinsics@1.1.0:
@@ -849,8 +1114,18 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+    dev: false
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
     dev: false
 
   /methods@1.1.2:
@@ -863,11 +1138,23 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
     dev: false
 
   /mime@1.6.0:
@@ -887,6 +1174,13 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+    dependencies:
+      content-type: 2.1.0
     dev: false
 
   /object-assign@4.1.1:
@@ -911,13 +1205,33 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
     dev: false
 
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: false
+
   /path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+    dev: false
+
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
     dev: false
 
   /prettier@3.8.3:
@@ -941,6 +1255,14 @@ packages:
       side-channel: 1.1.0
     dev: false
 
+  /qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+    dev: false
+
   /random-bytes@1.0.0:
     resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
     engines: {node: '>= 0.8'}
@@ -961,14 +1283,42 @@ packages:
       unpipe: 1.0.0
     dev: false
 
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+    dev: false
+
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
     dev: true
+
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -1005,6 +1355,25 @@ packages:
       - supports-color
     dev: false
 
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
@@ -1017,8 +1386,32 @@ packages:
       - supports-color
     dev: false
 
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
+
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: false
+
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
     dev: false
 
   /shell-quote@1.8.3:
@@ -1057,6 +1450,17 @@ packages:
 
   /side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    dev: false
+
+  /side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
@@ -1134,6 +1538,15 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+    dev: false
+
   /typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1166,6 +1579,14 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
+
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1174,6 +1595,10 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
     dev: true
+
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: false
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1197,6 +1622,18 @@ packages:
       y18n: 5.0.8
       yargs-parser: 21.1.1
     dev: true
+
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 3.25.76
+    dev: false
+
+  /zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    dev: false
 
   /zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - shared
   - agent-providers
   - agent-services
+  - agent-clients


### PR DESCRIPTION
## Summary

Adds the missing fourth role to the repo — the agent-side client — as a new `agent-clients/` workspace package (`authmd-agent-client`). It collapses the whole ceremony into 2–3 deterministic tool calls instead of the model driving each HTTP request:

- `authmd_authenticate(issuer, email?, resource?, id_jag?)` — reuse stored credentials for the issuer (cached access_token → live assertion → refresh-token rotation), else register with the lightest applicable method (`identity_assertion` when an ID-JAG is supplied, `service_auth` with an email, `anonymous` otherwise) and jwt-bearer exchange. Returns ready credentials or `{status: "claim_required", verification_uri}`.
- `authmd_complete_claim(issuer, user_code)` — direct `/agent/identity/claim/complete` with the code the user read back; persists the post-claim identity + rotating refresh token; exchanges.
- `authmd_fetch(issuer, url, ...)` — convenience wrapper injecting the bearer token with transparent refresh.

Structure: one shared core (`src/core/`: discovery, client state machine, credential store) with two thin adapters — an MCP stdio server (`src/mcp/`, for Claude Desktop via the `mcpb/manifest.json` bundle, Claude Code, and Codex) and a pi extension adapter (`src/pi/`, default-exports `activate(pi)` calling the core directly).

Design points:
- Everything is tenanted by issuer: independent registrations/credentials per service.
- Claim tokens live in memory only for the duration of the ceremony, per AUTH.md; assertions/refresh/access tokens persist in a `0600` file at `~/.authmd/credentials.json` behind a pluggable `CredentialStore` interface (an OS-keychain backend, e.g. `@napi-rs/keyring`, can slot in later).
- Targets the reconciled v0.7.0 protocol, hence based on `madison/reconcile`.

Verified end-to-end against the sample service (`pnpm dev`): anonymous → ready with pre-claim scope; credential reuse; authenticated fetch; service_auth → claim_required → scripted user login/confirm → `complete_claim` → post-claim scopes; refresh-token rotation after forced assertion expiry. MCP server responds to `initialize`/`tools/list` with the three tools.

Link to Devin session: https://app.devin.ai/sessions/3bbcaf8fae804f3caff9e7394cfaf640
Open in Devin Desktop: https://app.devin.ai/desktop/session/3bbcaf8fae804f3caff9e7394cfaf640?variant=devin
Requested by: @m0tzy