### PR TITLE
Reconcile spec with WorkOS implementation

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -62,21 +62,20 @@ Response shape:
   "issuer": "https://auth.service.example.com",
   "token_endpoint": "https://auth.service.example.com/oauth2/token",
   "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
-  "grant_types_supported": [
-    "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    "urn:workos:agent-auth:grant-type:claim"
-  ],
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
 
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
+    "identity_types_supported": [
+      "anonymous",
+      "identity_assertion",
+      "service_auth"
+    ],
     "identity_assertion": {
-      "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag"
-      ]
+      "assertion_types_supported": ["urn:ietf:params:oauth:token-type:id-jag"]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -90,10 +89,10 @@ The outer fields restate the PRM. The top-level OAuth endpoints (`issuer`, `toke
 - `issuer` — the canonical issuer URL of this authorization server. Validate the `iss` claim of any token the AS signs against this.
 - `token_endpoint` — where you exchange a service-signed identity assertion for an access_token (Step 5).
 - `revocation_endpoint` — where you POST to revoke an access_token ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)).
-- `grant_types_supported` — lists the grant types accepted at `/oauth2/token`. `urn:ietf:params:oauth:grant-type:jwt-bearer` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)) is for exchanging your identity_assertion for an access_token (Step 5). `urn:workos:agent-auth:grant-type:claim` is the polling grant for the claim ceremony (Step 4c) — a profile-specific URN so it doesn't collide with services that also implement standard RFC 8628 device authorization at the same endpoint.
+- `grant_types_supported` — lists the grant types accepted at `/oauth2/token`. Currently just `urn:ietf:params:oauth:grant-type:jwt-bearer` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)), for exchanging your identity_assertion for an access_token (Step 5). The claim ceremony does **not** run through `/oauth2/token` — you complete it at `agent_auth.claim_endpoint` (Step 4), not by polling a grant here.
 - `agent_auth.skill` — the URL of this document.
 - `agent_auth.identity_endpoint` — where you POST to register (Step 3).
-- `agent_auth.claim_endpoint` — where you POST the claim invite for anonymous registrations (Step 4) and where the agent polls for ceremony completion at `/view`.
+- `agent_auth.claim_endpoint` — where you POST to start a claim attempt (Step 4) and, at `/complete`, where you submit the `user_code` the user reads back to you.
 - `agent_auth.events_endpoint` — where the provider POSTs a [Security Event Token (RFC 8417)](https://datatracker.ietf.org/doc/html/rfc8417) per [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) push delivery to notify the service of upstream identity events. You don't call this; it tells you what to expect.
 - `agent_auth.identity_types_supported` — which registration methods this service accepts. Pick yours from Step 2.
 - `agent_auth.identity_assertion.assertion_types_supported` — which assertion types this service accepts under the `identity_assertion` shape (currently ID-JAG).
@@ -143,15 +142,17 @@ The response has two shapes depending on whether the service already has a deleg
 
 ```json
 {
-  "registration_id": "reg_...",
-  "registration_type": "identity_assertion",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "id": "reg_...",
+  "type": "identity_assertion",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z"
+  },
   "scopes": ["api.read", "api.write"]
 }
 ```
 
-Keep `identity_assertion` and go to [Step 5](#step-5--exchange-the-assertion).
+Keep `identity.assertion` and go to [Step 5](#step-5--exchange-the-assertion).
 
 **Confirmation required (401)** — `(iss, sub)` is unknown but the ID-JAG's verified email or phone matched an existing account at the service. The service won't silently bind the delegation — the user has to confirm linking the provider identity to their account.
 
@@ -162,22 +163,22 @@ WWW-Authenticate: AgentAuth error="interaction_required", error_description="…
 {
   "error": "interaction_required",
   "error_description": "…",
-  "registration_id": "reg_...",
-  "registration_type": "identity_assertion",
-  "claim_url": "https://auth.service.example.com/agent/identity/claim",
-  "claim_token": "clm_...",
-  "claim_token_expires": "…",
-  "post_claim_scopes": ["api.read", "api.write"],
+  "id": "reg_...",
+  "type": "identity_assertion",
+  "scopes": { "post_claim": ["api.read", "api.write"] },
   "claim": {
-    "user_code": "123456",
-    "expires_in": 600,
-    "verification_uri": "https://auth.service.example.com/login?return_to=%2Fclaim%3Fclaim_attempt_token%3D...",
-    "interval": 5
+    "token": "clm_...",
+    "expires_at": "…",
+    "url": "https://auth.service.example.com/agent/identity/claim",
+    "attempt": {
+      "verification_uri": "https://auth.service.example.com/agent-claim?token=...",
+      "expires_at": "…"
+    }
   }
 }
 ```
 
-Same `claim` block as the `service_auth` registration response — the user signs in to the service, sees a confirmation page that names your provider ("**Acme Provider** is asking to link this account so the agent it runs can act on your behalf"), and types the `user_code` to confirm. Surface `verification_uri` + `user_code` to the user (see [Step 4b](#4b-hand-off-to-the-user)) and poll the token endpoint (see [Step 4c](#4c-poll-for-completion)).
+Same `claim` block as the `service_auth` registration response. Hand the user `claim.attempt.verification_uri`; they sign in, see a confirmation page that names your provider ("**Acme Provider** is asking to link this account so the agent it runs can act on your behalf"), and the page reveals a `user_code`. They read it back to you, and you submit it with `claim.token` at `/agent/identity/claim/complete` (see [Step 4](#step-4--claim-ceremony)).
 
 After the user confirms, the next presentation of an ID-JAG for the same `(iss, sub, aud)` is accepted directly — no confirmation needed.
 
@@ -210,22 +211,22 @@ Response (200):
 
 ```json
 {
-  "registration_id": "reg_...",
-  "registration_type": "service_auth",
-  "claim_url": "https://auth.service.example.com/agent/identity/claim",
-  "claim_token": "clm_...",
-  "claim_token_expires": "2026-05-21T17:31:25.994Z",
-  "post_claim_scopes": ["api.read", "api.write"],
+  "id": "reg_...",
+  "type": "service_auth",
+  "scopes": { "post_claim": ["api.read", "api.write"] },
   "claim": {
-    "user_code": "123456",
-    "expires_in": 600,
-    "verification_uri": "https://auth.service.example.com/login?return_to=%2Fclaim%3Fclaim_attempt_token%3D...",
-    "interval": 5
+    "token": "clm_...",
+    "expires_at": "2026-05-21T17:31:25.994Z",
+    "url": "https://auth.service.example.com/agent/identity/claim",
+    "attempt": {
+      "verification_uri": "https://auth.service.example.com/agent-claim?token=...",
+      "expires_at": "2026-05-21T17:31:25.994Z"
+    }
   }
 }
 ```
 
-No `identity_assertion` yet — the claim ceremony is bundled into the registration response. Its shape borrows from [RFC 8628 device-authorization](https://datatracker.ietf.org/doc/html/rfc8628) (`user_code`, `verification_uri`, `expires_in`, `interval`) with a `claim_attempt_token` binding parameter embedded in `verification_uri` so the URL identifies the registration without leaking the user-typed `user_code`. The agent surfaces `claim.verification_uri` and `claim.user_code` to the user, and polls the `token_endpoint` from AS metadata with a profile-specific grant until the ceremony completes (see [Step 4](#step-4--claim-ceremony)). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
+No `identity_assertion` yet — the first claim attempt is bundled into the registration response under `claim.attempt`. Hand the user `claim.attempt.verification_uri` (it carries an opaque attempt token, never the `user_code`); they sign in there and the page reveals a `user_code` for them to read back to you. You then submit that code together with `claim.token` at `/agent/identity/claim/complete` (see [Step 4](#step-4--claim-ceremony)). `claim.token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
 
 ### anonymous
 
@@ -240,37 +241,44 @@ Response (200):
 
 ```json
 {
-  "registration_id": "reg_...",
-  "registration_type": "anonymous",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z",
-  "pre_claim_scopes": ["api.read"],
-  "claim_url": "https://auth.service.example.com/agent/identity/claim",
-  "claim_token": "clm_...",
-  "claim_token_expires": "2026-05-21T17:26:32.915Z",
-  "post_claim_scopes": ["api.read", "api.write"]
+  "id": "reg_...",
+  "type": "anonymous",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z"
+  },
+  "scopes": {
+    "pre_claim": ["api.read"],
+    "post_claim": ["api.read", "api.write"]
+  },
+  "claim": {
+    "token": "clm_...",
+    "expires_at": "2026-05-21T17:26:32.915Z",
+    "url": "https://auth.service.example.com/agent/identity/claim"
+  }
 }
 ```
 
-The `identity_assertion` exchanges at `/oauth2/token` for an access_token with `pre_claim_scopes` immediately. If you also want a human to take ownership and unlock `post_claim_scopes`, go to [Step 4](#step-4--claim-ceremony). Otherwise skip to [Step 5](#step-5--exchange-the-assertion). `claim_token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
+The `identity.assertion` exchanges at `/oauth2/token` for an access_token with `scopes.pre_claim` immediately. If you also want a human to take ownership and unlock `scopes.post_claim`, go to [Step 4](#step-4--claim-ceremony) — unlike service_auth, no attempt is pre-minted, so you start one at `/agent/identity/claim`. Otherwise skip to [Step 5](#step-5--exchange-the-assertion). `claim.token` is returned exactly once — hold it in memory for the duration of the ceremony; do not persist it past Step 4.
 
 ## Step 4 — Claim ceremony
 
-The end goal: get a signed-in user to confirm a 6-digit `user_code` **you supply them**. The code travels from you → user, not from the service → user; the user authenticates to the service and types the code into a page the service owns. This binds the agent's context to the user's authenticated session at the service. The ceremony fields (`user_code`, `verification_uri`, `expires_in`, `interval`) borrow their shape from [RFC 8628 device authorization](https://datatracker.ietf.org/doc/html/rfc8628), and polling happens at the standard `token_endpoint` with a profile-specific grant.
+The end goal: bind the registration to a signed-in user at the service. The `user_code` travels **service → user → you**: the user authenticates at the service, the service's claim page reveals a `user_code`, the user reads it back to you, and you submit it to finish. You never see the code until the user relays it, and the user never types a code you handed them. The ceremony is always the **service_auth** method — anonymous registrations are claimed this way too.
 
 ### 4a. Get the ceremony materials
 
-For **service_auth** registrations, you already have them — they're in the `claim` block of the Step 3 response. Skip to 4b.
+For **service_auth** registrations, the first attempt is already minted — it's in `claim.attempt` of the Step 3 response. Skip to 4b.
 
-For **anonymous** registrations, ask the service to start a ceremony:
+For **anonymous** registrations (and to re-mint an expired attempt for either kind), ask the service to start one:
 
 ```http
 POST /agent/identity/claim
 Content-Type: application/json
 
 {
+  "type": "service_auth",
   "claim_token": "clm_...",
-  "email": "user@example.com"
+  "login_hint": "user@example.com"
 }
 ```
 
@@ -278,87 +286,69 @@ Response (200):
 
 ```json
 {
-  "registration_id": "reg_...",
-  "claim_attempt_id": "cla_...",
-  "status": "initiated",
-  "expires_at": "2026-05-21T17:31:25.994Z",
-  "claim_attempt": {
-    "user_code": "123456",
-    "expires_in": 600,
-    "verification_uri": "https://auth.service.example.com/login?return_to=%2Fclaim%3Fclaim_attempt_token%3D...",
-    "interval": 5
+  "id": "reg_...",
+  "type": "service_auth",
+  "attempt": {
+    "verification_uri": "https://auth.service.example.com/agent-claim?token=...",
+    "expires_at": "2026-05-21T17:31:25.994Z"
   }
 }
 ```
 
-The `claim_attempt` block here — same shape as the `claim` block in the `service_auth` registration response — borrows from [RFC 8628 device-authorization](https://datatracker.ietf.org/doc/html/rfc8628), with `claim_attempt_token` embedded in `verification_uri` so the URL identifies the registration without leaking the user-typed `user_code`. Surface `verification_uri` + `user_code` to the user; poll the standard `token_endpoint` from AS metadata with the claim grant (see 4c).
-
-The `email` you supply on anonymous `/claim` binds the registration to the human you intend the agent to act on behalf of — only that signed-in user can complete the ceremony. Without this, a third party who intercepted the `user_code` could claim the agent for themselves.
+`type` is the claim method, not the registration kind — anonymous registrations are claimed via `service_auth` too. The `verification_uri` carries an opaque attempt token that identifies the registration without leaking the `user_code` (which the service never puts in this response). The `login_hint` binds the attempt to the human you intend the agent to act on behalf of — only that signed-in user can complete the ceremony, so a third party who intercepted the link can't claim the agent for themselves.
 
 ### 4b. Hand off to the user
 
-Surface `verification_uri` and `user_code` to the user in a single message. Suggested copy:
+Surface `attempt.verification_uri` to the user. Suggested copy:
 
-> Open this link, sign in (or sign up), and enter this 6-digit code: **123456**
-> https://auth.service.example.com/login?return_to=...
+> Open this link and sign in (or sign up). You'll see a 6-digit code on the page — read it back to me.
+> https://auth.service.example.com/agent-claim?token=...
 
-Be explicit that the code goes into the page they land on after signing in — not back to you. The user will:
+Be explicit that the code comes **from the page back to you** — they don't type anything you gave them. The user will:
 
 1. Open `verification_uri`.
 2. Authenticate with the service (existing user → sign in; new user → sign up and verify email, depending on the service).
-3. Land on the claim page, see "you're signed in as <email>", type the `user_code`, and submit.
+3. Land on the claim page, see "you're signed in as <email>", and confirm. The page reveals the `user_code`.
+4. Read the `user_code` back to you.
 
-### 4c. Poll for completion
+### 4c. Complete the claim
 
-Poll the standard `token_endpoint` (from AS metadata) with the profile-specific claim grant, passing your `claim_token`:
+Submit the `user_code` the user read back, together with your `claim_token`:
 
 ```http
-POST /oauth2/token
-Content-Type: application/x-www-form-urlencoded
+POST /agent/identity/claim/complete
+Content-Type: application/json
 
-grant_type=urn:workos:agent-auth:grant-type:claim
-&claim_token=<clm_...>
-```
-
-Why a profile-specific grant URN (and not `urn:ietf:params:oauth:grant-type:device_code` directly)? So this surface doesn't collide with a service that also implements standard RFC 8628 device authorization at the same token endpoint — the AS routes by grant_type, no risk of a claim_token being looked up in a device-auth store or vice versa.
-
-Response while waiting (RFC 8628 §3.5 vocabulary):
-
-```json
-{ "error": "authorization_pending", "error_description": "..." }
-```
-
-Response on success: a standard OAuth token response, plus an `identity_assertion` extension so you have a refresh path via the JWT-bearer grant once this access_token expires.
-
-```json
 {
-  "access_token": "<post-claim access_token>",
-  "token_type": "Bearer",
-  "expires_in": 3600,
-  "scope": "api.read api.write",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-21T18:31:25.994Z"
+  "claim_token": "clm_...",
+  "user_code": "123456"
 }
 ```
 
-Use `access_token` immediately on `/api/resource`; cache `identity_assertion` for the eventual refresh.
+There is no polling and no claim grant at `/oauth2/token` — you drive completion directly here with the code the user relayed. (The page the user confirmed on calls a separate, session-gated `/agent/identity/claim/view` to reveal the code; you never call that.)
 
-For **anonymous** flows, completion of the ceremony **revokes** any pre-claim access_tokens you held. Use the post-claim access_token from this response; drop the pre-claim one. The pre-claim `identity_assertion` (v1) also gets superseded by the v2 returned here — the v2 carries the user's email/email_verified claims, the v1 didn't.
-
-If the `user_code` window passes without the user finishing:
+Response on success — the post-claim identity, returned exactly once: the service-signed `identity.assertion` plus a rotating `refresh_token`. There is no access_token here; mint one at [Step 5](#step-5--exchange-the-assertion).
 
 ```json
-{ "error": "expired_token", "error_description": "..." }
+{
+  "id": "reg_...",
+  "status": "claimed",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-21T18:31:25.994Z",
+    "refresh_token": {
+      "value": "<refresh token>",
+      "expires_at": "2026-06-21T17:31:25.994Z"
+    }
+  }
+}
 ```
 
-Two cases distinguish what to do next:
+Persist this response — it's the only time the `refresh_token` plaintext is handed back (see [Step 6](#step-6--use-the-access_token) for how it's used). Then exchange `identity.assertion` for an access_token at [Step 5](#step-5--exchange-the-assertion).
 
-- **Registration is still active** (most common — the user_code's 10-minute timer expired but the outer claim window is still open): call `POST /agent/identity/claim` with the same `claim_token` and the same `email` to mint a fresh `claim_attempt` block. Surface the new `user_code` and `verification_uri` to the user and resume polling. This works for both anonymous and service_auth registrations.
-- **Registration itself has expired** (the outer claim window — typically 24h — has closed): start over at Step 3.
+For **anonymous** flows, completing the claim **revokes** any pre-claim access_tokens you held, and the pre-claim `identity.assertion` is superseded by the one returned here — the new one carries the user's email/email_verified claims, the pre-claim one didn't. Drop the pre-claim credentials and use the post-claim identity.
 
-If you can't tell which it is from context, try re-initiating first; the claim endpoint returns `410 claim_expired` if the registration is gone, at which point you restart at Step 3.
-
-Honor `interval` (in seconds); on `slow_down` back off. The next poll after `expires_in` will return `expired_token`.
+While the user hasn't finished on the page yet, `/complete` returns `claim_not_confirmed` — wait and retry. If the user reads the code wrong, it returns `invalid_user_code` — ask them to read it again. If the `user_code` window closes (`user_code_expired`), re-call `POST /agent/identity/claim` for a fresh attempt and hand the user the new link; if that returns `claim_expired`, the outer claim window (typically 24h) has closed — restart at [Step 3](#step-3--register).
 
 ## Step 5 — Exchange the assertion
 
@@ -384,9 +374,9 @@ Response (200):
 }
 ```
 
-Extract `access_token` and go to [Step 6](#step-6--use-the-access_token). The same `identity_assertion` can be re-used to mint additional access_tokens until it expires.
+Extract `access_token` and go to [Step 6](#step-6--use-the-access_token). The same `identity.assertion` can be re-used to mint additional access_tokens until it expires.
 
-If `/oauth2/token` returns `invalid_grant`, your `identity_assertion` is expired or revoked. Restart the flow at [Step 3](#step-3--register) to mint a fresh identity assertion.
+If `/oauth2/token` returns `invalid_grant`, your assertion is expired or revoked. Restart the flow at [Step 3](#step-3--register) to mint a fresh identity assertion (or refresh it — see [Step 6](#step-6--use-the-access_token)).
 
 ## Step 6 — Use the access_token
 
@@ -397,7 +387,20 @@ GET /api/some-resource
 Authorization: Bearer <access_token>
 ```
 
-**Refresh.** When the access_token expires (`expires_in` seconds after issuance), re-call [Step 5](#step-5--exchange-the-assertion) with the same `identity_assertion`. When the identity assertion itself expires or `/oauth2/token` returns `invalid_grant`, restart at [Step 3](#step-3--register). There is no OAuth refresh_token in this flow — the two-step pattern replaces it.
+**Refresh.** When the access_token expires (`expires_in` seconds after issuance), re-call [Step 5](#step-5--exchange-the-assertion) with the same stored `identity.assertion` — the assertion outlives individual access_tokens. When the assertion itself expires, how you recover depends on how you registered:
+
+- **service_auth (and claimed anonymous):** your stored response carries a `refresh_token`. Exchange it for a fresh assertion — which also rotates the refresh token:
+
+  ```http
+  POST /agent/identity
+  Content-Type: application/json
+
+  { "type": "refresh", "refresh_token": "<refresh token>" }
+  ```
+
+  The response is a registration with a fresh `identity.assertion` and a new `refresh_token`; persist it (the old refresh token is now spent) and return to [Step 5](#step-5--exchange-the-assertion). If it returns `invalid_refresh_token`, the token is expired or already used — restart at [Step 3](#step-3--register).
+
+- **anonymous (pre-claim) and identity_assertion:** there is no refresh token — re-register at [Step 3](#step-3--register) (for identity_assertion, mint a fresh ID-JAG).
 
 If you get a 401 on a previously-working access_token: try [Step 5](#step-5--exchange-the-assertion) once with the current assertion. If that also fails, discard the expired identity assertion, and restart at [Step 1](#step-1--discover).
 
@@ -407,26 +410,32 @@ Full API reference: `https://docs.service.example.com/`.
 
 Errors at `/agent/identity` and `/agent/identity/claim/*` use profile-specific codes (the registration ceremonies have no OAuth analog). Errors at `/oauth2/token` use OAuth-standard vocabulary per [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) / [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523).
 
-| Code                         | Where                         | What to do                                                                                                                                                                             |
-| ---------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `anonymous_not_enabled`      | `/agent/identity`             | This service doesn't accept anonymous. Pick another method from Step 2.                                                                                                                |
-| `service_auth_not_enabled`   | `/agent/identity`             | service_auth (email-based) disabled here. Pick another method.                                                                                                                         |
-| `issuer_not_enabled`         | `/agent/identity`             | Provider not on this service's trust list. Pick another method.                                                                                                                        |
-| `invalid_request`            | `/agent/identity`             | Body shape, missing claims, ID-JAG signature/`jti`/`aud` problems, or unverified identity. Fix the input (mint a fresh ID-JAG if signature/`jti`/`aud`/`exp`-related).                 |
-| `interaction_required` (401) | `/agent/identity` (ID-JAG)    | Step-up: ID-JAG matched an existing account but no `(iss, sub)` delegation yet. Body carries a `claim` block; surface it to the user (see [Step 4](#step-4--claim-ceremony)).          |
-| `login_required` (401)       | `/agent/identity` (ID-JAG)    | `auth_time` missing or older than `max_age`. Re-authenticate the user at your provider (`prompt=login` or equivalent) and mint a fresh ID-JAG. The service can't help here.            |
-| `invalid_claim_token`        | `/agent/identity/claim`       | `claim_token` wrong or expired. Restart at Step 3.                                                                                                                                     |
-| `claimed_or_in_flight`       | `/agent/identity/claim`       | Wrong endpoint for this registration kind, or already claimed. Re-read the Step 3 response and follow Step 4.                                                                          |
-| `claim_expired`              | `/agent/identity/claim`       | The registration expired before the user finished. Restart at Step 3.                                                                                                                  |
-| `invalid_grant`              | `/oauth2/token`               | Assertion expired, revoked, replayed, or otherwise failed verification. Restart at [Step 3](#step-3--register) to mint a fresh one.                                                    |
-| `invalid_client`             | `/oauth2/token`               | `client_id` not recognized. Re-read AS metadata.                                                                                                                                       |
-| `unsupported_grant_type`     | `/oauth2/token`               | `grant_type` is not one of the two supported values (`urn:ietf:params:oauth:grant-type:jwt-bearer` for token exchange, `urn:workos:agent-auth:grant-type:claim` for ceremony polling). |
-| `authorization_pending`      | `/oauth2/token` (claim grant) | User hasn't completed the ceremony yet. Honor `interval` from the `claim` or `claim_attempt` block; retry.                                                                             |
-| `expired_token`              | `/oauth2/token` (claim grant) | `user_code` window or outer claim window has closed. Re-call `/agent/identity/claim` to mint a fresh user_code; if that returns `claim_expired`, restart at Step 3.                    |
-| `slow_down`                  | `/oauth2/token` (claim grant) | Polling too fast. Add at least 5s to your `interval` and retry.                                                                                                                        |
-| `rate_limited` (429)         | any                           | Back off and retry.                                                                                                                                                                    |
+| Code                                 | Where                                       | What to do                                                                                                                                                              |
+| ------------------------------------ | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `anonymous_registration_disabled`    | `/agent/identity`                           | This service doesn't accept anonymous registration. Pick another method from Step 2.                                                                                    |
+| `service_auth_registration_disabled` | `/agent/identity`                           | service_auth disabled here. Pick another method.                                                                                                                        |
+| `issuer_not_enabled`                 | `/agent/identity` (ID-JAG)                  | Provider not on this service's trust list. Pick another method.                                                                                                         |
+| `invalid_request`                    | `/agent/identity`, `/agent/identity/claim*` | Body shape or missing/invalid fields (incl. ID-JAG signature/`jti`/`aud`). Fix the input.                                                                               |
+| `invalid_login_hint`                 | `/agent/identity` (service_auth), `…/claim` | `login_hint` isn't a valid email. Fix it.                                                                                                                               |
+| `interaction_required` (401)         | `/agent/identity` (ID-JAG)                  | Step-up: ID-JAG matched an existing account but no `(iss, sub)` delegation yet. Body carries a `claim` block; run the ceremony (see [Step 4](#step-4--claim-ceremony)). |
+| `login_required` (401)               | `/agent/identity` (ID-JAG)                  | `auth_time` missing or older than `max_age`. Re-authenticate at your provider (`prompt=login` or equivalent) and mint a fresh ID-JAG. The service can't help here.      |
+| `invalid_refresh_token`              | `/agent/identity` (refresh)                 | Refresh token wrong, expired, or already used. Restart at Step 3.                                                                                                       |
+| `invalid_claim_token`                | `/agent/identity/claim`                     | `claim_token` wrong. Restart at Step 3.                                                                                                                                 |
+| `claim_revoked` (410)                | `/agent/identity/claim`                     | The claim was revoked. Restart at Step 3.                                                                                                                               |
+| `too_many_attempts` (429)            | `/agent/identity/claim`                     | Too many live attempts on this claim. Wait for one to expire or complete.                                                                                               |
+| `claim_expired` (410)                | `/agent/identity/claim`, `…/claim/complete` | The outer claim window closed before the user finished. Restart at Step 3.                                                                                              |
+| `auth_method_disabled` (403)         | `/agent/identity/claim`, `…/claim/complete` | service_auth claim disabled for this environment. Pick another method.                                                                                                  |
+| `claim_not_confirmed` (409)          | `/agent/identity/claim/complete`            | User hasn't approved on the page yet. Wait and retry.                                                                                                                   |
+| `invalid_user_code` (401)            | `/agent/identity/claim/complete`            | Wrong code. Ask the user to re-read it off the page.                                                                                                                    |
+| `user_code_expired` (410)            | `/agent/identity/claim/complete`            | The code's window closed. Re-call `/agent/identity/claim` for a fresh attempt.                                                                                          |
+| `claim_denied` (403)                 | `/agent/identity/claim/complete`            | The user denied the claim. Start a new attempt only if appropriate.                                                                                                     |
+| `already_claimed` (409)              | `/agent/identity/claim`, `…/claim/complete` | This registration is already claimed. Re-read the Step 3 response.                                                                                                      |
+| `invalid_grant`                      | `/oauth2/token`                             | Assertion expired, revoked, replayed, or otherwise failed verification. Restart at [Step 3](#step-3--register) to mint a fresh one.                                     |
+| `invalid_client`                     | `/oauth2/token`                             | `client_id` not recognized. Re-read AS metadata.                                                                                                                        |
+| `unsupported_grant_type`             | `/oauth2/token`                             | `grant_type` must be `urn:ietf:params:oauth:grant-type:jwt-bearer`.                                                                                                     |
+| `rate_limit_exceeded` (429)          | any                                         | Back off and retry; honor the `retry_after` field / `Retry-After` header.                                                                                               |
 
-`user_code` errors are surfaced to the user on the claim page — they never reach you. Your poll keeps returning `"status": "pending"` until either the user gets the code right or the window expires (`"status": "expired"`).
+The `user_code` reaches you only when the user reads it back off the claim page; you submit it at `/agent/identity/claim/complete`. A wrong code returns `invalid_user_code` (ask the user to read it again), and `claim_not_confirmed` means the user hasn't approved on the page yet (wait and retry).
 
 Retry policy:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # auth.md Changelog
 
+## v0.7.0 (2026-06-26)
+
+Reverses the v0.4.0 claim-ceremony direction to match the shipped service. The `user_code` is no longer minted by the agent for the user to type into a service page. Instead the agent hands the user a `verification_uri` only; the user signs in, the service's claim page reveals the `user_code`, and the user reads it back to the agent, which submits it to complete the claim. The agent no longer polls — completion is a direct call to `/agent/identity/claim/complete`. Also documents the `service_auth` refresh-token path (the spec previously stated there was no refresh token) and reshapes the registration/ceremony responses into the nested envelope the service emits.
+
+### Added
+
+- `POST /agent/identity/claim/complete` — the agent submits the `user_code` the user read back, plus its `claim_token`, and collects the post-claim identity (`identity.assertion` + a rotating `refresh_token`) as a one-shot response.
+- `refresh` registration type at `/agent/identity` — `{ "type": "refresh", "refresh_token": "…" }` exchanges a refresh token for a fresh `identity.assertion`, rotating the refresh token. Carried by `service_auth` and claimed-anonymous registrations.
+- `verification_uri` now embeds an opaque attempt token; the `user_code` is revealed only on the service's claim page, via a session-gated `/agent/identity/claim/view` the agent never calls.
+- Error codes for the direct-completion ceremony: `invalid_login_hint`, `claim_revoked`, `too_many_attempts`, `auth_method_disabled`, `claim_not_confirmed`, `invalid_user_code`, `user_code_expired`, `claim_denied`, `already_claimed`, `invalid_refresh_token`.
+
+### Changed
+
+- Claim ceremony direction: `user_code` travels service → user → agent (revealed in the browser), not agent → user.
+- `POST /agent/identity/claim` body: `{ claim_token, email }` → `{ type: "service_auth", claim_token, login_hint }`. `type` is the claim method — anonymous registrations are claimed via `service_auth` too — and the binding identifier follows CIBA's `login_hint`.
+- Registration and ceremony responses moved to a nested envelope: `registration_id`/`registration_type` → `id`/`type`; `identity_assertion`/`assertion_expires` → `identity.{assertion,expires_at}`; `claim_token`/`claim_token_expires`/`claim_url` → `claim.{token,expires_at,url}`; flat `pre_claim_scopes`/`post_claim_scopes` → `scopes.{pre_claim,post_claim}`; `verification_uri` → `claim.attempt.verification_uri`.
+- Refresh model: `service_auth` (and claimed anonymous) registrations carry a rotating `refresh_token`; anonymous (pre-claim) and `identity_assertion` still re-exchange the assertion or re-register.
+- Error codes renamed to match the service: `anonymous_not_enabled` → `anonymous_registration_disabled`, `service_auth_not_enabled` → `service_auth_registration_disabled`, `claimed_or_in_flight` → `already_claimed`, `rate_limited` → `rate_limit_exceeded`.
+
+### Removed
+
+- `urn:workos:agent-auth:grant-type:claim` polling grant at `/oauth2/token`, and its `authorization_pending` / `expired_token` / `slow_down` response vocabulary. Completion is the direct `/agent/identity/claim/complete` call.
+- `user_code`, `expires_in`, and `interval` from all agent-facing registration and claim responses — the code is shown on the claim page, and there is no polling interval to honor.
+- The claim grant from `grant_types_supported` (now just `urn:ietf:params:oauth:grant-type:jwt-bearer`).
+
 ## v0.6.0 (2026-06-10)
 
 Splits the email-based registration path out from `identity_assertion` and into a top-level `service_auth` registration type, with a body modeled on [OIDC CIBA](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)'s `login_hint`. The previous shape was honest about how it worked — the service was verifying the email, not the agent — but it was filed under `identity_assertion` like the agent was asserting something. CIBA's vocabulary fits: the agent is hinting at who the user is, and the service authenticates the user out-of-band.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Service at <http://localhost:8000>, provider at <http://localhost:4000>. The ser
 
 ## System Flows
 
-Registration and credential issuance are split across two endpoints. `POST /agent/identity` accepts the agent's chosen identity assertion (ID-JAG, verified email, or anonymous) and returns a service-signed `identity_assertion`. The agent then exchanges that assertion at `POST /oauth2/token` (RFC 7523 JWT-bearer grant) for an access_token.
+Registration and credential issuance are split across two endpoints. `POST /agent/identity` accepts the agent's chosen identity type (ID-JAG, service_auth via email, or anonymous). ID-JAG and anonymous return a service-signed `identity.assertion` immediately; service_auth returns a claim ceremony to run first. The agent then exchanges the assertion at `POST /oauth2/token` (RFC 7523 JWT-bearer grant) for an access_token.
 
 ### Discovery
 
@@ -47,21 +47,20 @@ Hosted at `/.well-known/oauth-authorization-server`:
   "issuer": "https://auth.service.example.com",
   "token_endpoint": "https://auth.service.example.com/oauth2/token",
   "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
-  "grant_types_supported": [
-    "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    "urn:workos:agent-auth:grant-type:claim"
-  ],
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
 
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
+    "identity_types_supported": [
+      "anonymous",
+      "identity_assertion",
+      "service_auth"
+    ],
     "identity_assertion": {
-      "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag"
-      ]
+      "assertion_types_supported": ["urn:ietf:params:oauth:token-type:id-jag"]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -98,13 +97,13 @@ sequenceDiagram
     Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion: ID-JAG }
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
-    Service-->>Agent: 200 OK (identity_assertion)
+    Service-->>Agent: 200 OK (identity.assertion)
 
     Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
     Service-->>Agent: 200 OK (access_token)
 ```
 
-### Verified-Email Identity Assertion
+### Service Auth (Email-Based Claim)
 
 ```mermaid
 sequenceDiagram
@@ -113,22 +112,22 @@ sequenceDiagram
     participant Service
 
     Agent->>Service: POST /agent/identity<br/>{ type: service_auth, login_hint: email }
-    Service-->>Agent: 200 OK (claim_token, claim: user_code + verification_uri)
-    Agent-->>User: Surface user_code + verification_uri
-    User->>Service: GET verification_uri (signs in, lands on /claim)
-    User->>Service: POST /agent/identity/claim/complete<br/>{ claim_attempt_token, user_code }
-
-    loop until claimed
-      Agent->>Service: POST /oauth2/token<br/>grant_type=claim&claim_token=...
-      alt user_code window open
-        Service-->>Agent: 200 OK (access_token + identity_assertion) | authorization_pending
-      else user_code expired (outer claim window still open)
-        Service-->>Agent: 400 expired_token
-        Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
-        Service-->>Agent: 200 OK (fresh claim_attempt: new user_code + verification_uri)
-        Agent-->>User: Surface new user_code + verification_uri
-      end
+    Service-->>Agent: 200 OK (claim.token, claim.attempt.verification_uri)
+    Agent-->>User: Surface verification_uri (no code)
+    User->>Service: GET verification_uri (signs in, lands on /agent-claim)
+    Service-->>User: Reveals user_code on the page
+    User-->>Agent: Reads user_code back
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, user_code }
+    alt user_code correct & confirmed
+      Service-->>Agent: 200 OK (identity.assertion + refresh_token)
+    else user_code window expired
+      Service-->>Agent: 410 user_code_expired
+      Agent->>Service: POST /agent/identity/claim<br/>{ type: service_auth, claim_token, login_hint }
+      Service-->>Agent: 200 OK (fresh attempt.verification_uri)
+      Agent-->>User: Surface new verification_uri
     end
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (access_token)
 ```
 
 ### Anonymous Registration with Claim Ceremony
@@ -140,28 +139,21 @@ sequenceDiagram
     participant Service
 
     Agent->>Service: POST /agent/identity<br/>{ type: anonymous }
-    Service-->>Agent: 200 OK (identity_assertion, claim_token)
+    Service-->>Agent: 200 OK (identity.assertion, claim.token)
     Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
     Service-->>Agent: 200 OK (access_token with pre-claim scope)
 
     Note over Agent: Agent operates with pre-claim scopes
 
     User-->>Agent: Wants to take ownership
-    Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
-    Service-->>Agent: 200 OK (claim_attempt: user_code + verification_uri)
-    Agent-->>User: Surface user_code + verification_uri
-    User->>Service: GET verification_uri (signs in, lands on /claim)
-    User->>Service: POST /agent/identity/claim/complete<br/>{ claim_attempt_token, user_code }
-
-    loop until claimed
-      Agent->>Service: POST /oauth2/token<br/>grant_type=claim&claim_token=...
-      alt user_code window open
-        Service-->>Agent: 200 OK (post-claim access_token + v2 identity_assertion) | authorization_pending
-      else user_code expired (outer claim window still open)
-        Service-->>Agent: 400 expired_token
-        Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
-        Service-->>Agent: 200 OK (fresh claim_attempt: new user_code + verification_uri)
-        Agent-->>User: Surface new user_code + verification_uri
-      end
-    end
+    Agent->>Service: POST /agent/identity/claim<br/>{ type: service_auth, claim_token, login_hint }
+    Service-->>Agent: 200 OK (attempt.verification_uri)
+    Agent-->>User: Surface verification_uri (no code)
+    User->>Service: GET verification_uri (signs in, lands on /agent-claim)
+    Service-->>User: Reveals user_code on the page
+    User-->>Agent: Reads user_code back
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, user_code }
+    Service-->>Agent: 200 OK (v2 identity.assertion + refresh_token)
+    Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
+    Service-->>Agent: 200 OK (post-claim access_token)
 ```

--- a/agent-providers/README.md
+++ b/agent-providers/README.md
@@ -32,7 +32,7 @@ sequenceDiagram
     Agent->>Service: POST /agent/identity<br/>{ type: identity_assertion, assertion: ID-JAG }
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
-    Service-->>Agent: 200 OK (identity_assertion)
+    Service-->>Agent: 200 OK (identity.assertion)
 
     Agent->>Service: POST /oauth2/token<br/>grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=...
     Service-->>Agent: 200 OK (access_token)
@@ -75,17 +75,18 @@ Discovery is two-hop:
      "issuer": "https://auth.service.example.com",
      "token_endpoint": "https://auth.service.example.com/oauth2/token",
      "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
-     "grant_types_supported": [
-       "urn:ietf:params:oauth:grant-type:jwt-bearer",
-       "urn:workos:agent-auth:grant-type:claim"
-     ],
+     "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
 
      "agent_auth": {
        "skill": "https://service.example.com/auth.md",
        "identity_endpoint": "https://auth.service.example.com/agent/identity",
        "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
        "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-       "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
+       "identity_types_supported": [
+         "anonymous",
+         "identity_assertion",
+         "service_auth"
+       ],
        "identity_assertion": {
          "assertion_types_supported": [
            "urn:ietf:params:oauth:token-type:id-jag"
@@ -175,14 +176,16 @@ Content-Type: application/json
 }
 ```
 
-200 response — the service verified the ID-JAG, found or JIT-provisioned the user, and minted a service-signed `identity_assertion`:
+200 response — the service verified the ID-JAG, found or JIT-provisioned the user, and minted a service-signed identity assertion under `identity.assertion`:
 
 ```json
 {
-  "registration_id": "reg_...",
-  "registration_type": "identity_assertion",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "id": "reg_...",
+  "type": "identity_assertion",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z"
+  },
   "scopes": ["api.read", "api.write"]
 }
 ```
@@ -195,7 +198,7 @@ Host: auth.service.example.com
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
-&assertion=<service-signed identity_assertion>
+&assertion=<service-signed identity assertion>
 &resource=https://api.service.example.com/
 ```
 

--- a/agent-services/README.md
+++ b/agent-services/README.md
@@ -4,11 +4,11 @@ Services that want agents to authenticate on behalf of users — via Identity As
 
 This guide covers three flows:
 
-1. **ID-JAG identity assertion** — trusted agent providers (OpenAI, Anthropic, Cursor, etc.) assert a user's identity with an ID-JAG. The service verifies the assertion and returns a service-signed identity_assertion the agent exchanges at the token endpoint for an access_token.
-2. **Verified-email identity assertion** — the agent gives us a user email; the service mints a 6-digit `user_code` and returns it to the agent, the agent surfaces it to the user, the user signs in on a service page and types the code to authorize the agent.
-3. **Anonymous registration** — an agent with no user identity self-registers for a pre-claim identity_assertion and optionally invites a human to take ownership later via the same code-handoff ceremony.
+1. **ID-JAG identity assertion** — trusted agent providers (OpenAI, Anthropic, Cursor, etc.) assert a user's identity with an ID-JAG. The service verifies the assertion and returns a service-signed identity assertion the agent exchanges at the token endpoint for an access_token.
+2. **service_auth (email-based claim)** — the agent gives us a user email as a `login_hint`; the service hands the agent a `verification_uri` (no code), the agent hands it to the user, the user signs in on a service page and confirms, and the page reveals a 6-digit `user_code` the user reads back to the agent. The agent submits that code to finish.
+3. **Anonymous registration** — an agent with no user identity self-registers for a pre-claim identity assertion and optionally invites a human to take ownership later via the same claim ceremony.
 
-All three flows share the same `/agent/identity` registration endpoint and terminate at `/oauth2/token` (RFC 7523 JWT-bearer) for credential issuance. Verified-email and anonymous flows additionally use the [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) device-authorization-shaped claim ceremony.
+All three flows share the same `/agent/identity` registration endpoint and terminate at `/oauth2/token` (RFC 7523 JWT-bearer) for credential issuance. service_auth and anonymous flows additionally use the claim ceremony, whose ceremony fields borrow their shape from [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) device authorization — but the `user_code` travels service → user → agent (revealed on the service's page, read back to the agent), and the agent completes at `/agent/identity/claim/complete` rather than polling.
 
 **Why adopt this.** ID-JAG is a near-drop-in if your service already JIT-provisions users via OIDC or SAML — it's standard JWT verification against a provider JWKS plus a delegation record per `(iss, sub, aud)`, with no user-model changes. The claim flows are a real extension (a pre-claim principal state, a claim state machine, a scope-set swap) but they unlock MCP-server agents that start with no user identity — a use case nothing else handles cleanly. All three flows give users a real revoke surface for agent delegations, instead of copy-pasted API keys the service has no visibility into.
 
@@ -41,7 +41,7 @@ sequenceDiagram
     Service->>Provider: GET /.well-known/jwks.json
     Provider-->>Service: 200 OK (JSON Web Key Set)
     Service->>Service: Verify signature + claims, match user
-    Service-->>Agent: 200 OK (identity_assertion)
+    Service-->>Agent: 200 OK (identity.assertion)
 
     Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
     Service-->>Agent: 200 OK (access_token)
@@ -56,27 +56,25 @@ sequenceDiagram
     participant Service
 
     Agent->>Service: POST /agent/identity<br/>{ type: anonymous }
-    Service-->>Agent: 200 OK (identity_assertion, claim_token)
+    Service-->>Agent: 200 OK (identity.assertion, claim.token)
     Agent->>Service: POST /oauth2/token<br/>grant_type=jwt-bearer&assertion=...
     Service-->>Agent: 200 OK (access_token, pre-claim scope)
 
     Note over Agent: Agent operates with pre-claim scopes
 
     User-->>Agent: Wants to take ownership
-    Agent->>Service: POST /agent/identity/claim<br/>{ claim_token, email }
-    Service-->>Agent: 200 OK (claim_attempt: user_code, verification_uri)
-    Agent-->>User: Surface user_code + verification_uri
+    Agent->>Service: POST /agent/identity/claim<br/>{ type: service_auth, claim_token, login_hint }
+    Service-->>Agent: 200 OK (attempt.verification_uri)
+    Agent-->>User: Surface verification_uri (no code)
     User->>Service: GET verification_uri (signs in, lands on /claim)
-    User->>Service: POST /agent/identity/claim/complete<br/>{ claim_attempt_token, user_code }
-    Service-->>User: 200 OK (claim page confirms)
-
-    loop until claimed
-      Agent->>Service: POST /oauth2/token<br/>grant_type=urn:workos:agent-auth:grant-type:claim&claim_token=...
-      Service-->>Agent: 200 OK (post-claim access_token + v2 identity_assertion) | authorization_pending
-    end
+    User->>Service: POST /claim/confirm (confirms)
+    Service-->>User: Reveals user_code on the page
+    User-->>Agent: Reads user_code back
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, user_code }
+    Service-->>Agent: 200 OK (post-claim identity.assertion + refresh_token)
 ```
 
-### Verified-Email Identity Assertion
+### Service Auth (Email-Based Claim)
 
 ```mermaid
 sequenceDiagram
@@ -85,16 +83,14 @@ sequenceDiagram
     participant Service
 
     Agent->>Service: POST /agent/identity<br/>{ type: service_auth, login_hint: email }
-    Service-->>Agent: 200 OK (claim_token, claim: user_code, verification_uri)
-    Agent-->>User: Surface user_code + verification_uri
+    Service-->>Agent: 200 OK (claim.token, claim.attempt.verification_uri)
+    Agent-->>User: Surface verification_uri (no code)
     User->>Service: GET verification_uri (signs in as asserted email, lands on /claim)
-    User->>Service: POST /agent/identity/claim/complete<br/>{ claim_attempt_token, user_code }
-    Service-->>User: 200 OK (claim page confirms)
-
-    loop until claimed
-      Agent->>Service: POST /oauth2/token<br/>grant_type=urn:workos:agent-auth:grant-type:claim&claim_token=...
-      Service-->>Agent: 200 OK (access_token + identity_assertion) | authorization_pending
-    end
+    User->>Service: POST /claim/confirm (confirms)
+    Service-->>User: Reveals user_code on the page
+    User-->>Agent: Reads user_code back
+    Agent->>Service: POST /agent/identity/claim/complete<br/>{ claim_token, user_code }
+    Service-->>Agent: 200 OK (identity.assertion + refresh_token)
 ```
 
 ## Minimum Consumer Implementation
@@ -143,21 +139,20 @@ AS metadata:
   "issuer": "https://auth.service.example.com",
   "token_endpoint": "https://auth.service.example.com/oauth2/token",
   "revocation_endpoint": "https://auth.service.example.com/oauth2/revoke",
-  "grant_types_supported": [
-    "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    "urn:workos:agent-auth:grant-type:claim"
-  ],
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
 
   "agent_auth": {
     "skill": "https://service.example.com/auth.md",
     "identity_endpoint": "https://auth.service.example.com/agent/identity",
     "claim_endpoint": "https://auth.service.example.com/agent/identity/claim",
     "events_endpoint": "https://auth.service.example.com/agent/event/notify",
-    "identity_types_supported": ["anonymous", "identity_assertion", "service_auth"],
+    "identity_types_supported": [
+      "anonymous",
+      "identity_assertion",
+      "service_auth"
+    ],
     "identity_assertion": {
-      "assertion_types_supported": [
-        "urn:ietf:params:oauth:token-type:id-jag"
-      ]
+      "assertion_types_supported": ["urn:ietf:params:oauth:token-type:id-jag"]
     },
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
@@ -168,7 +163,7 @@ AS metadata:
 
 Top-level `issuer` / `token_endpoint` / `revocation_endpoint` / `grant_types_supported` follow [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) (with `revocation_endpoint` per [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). The `agent_auth` block is a profile extension for the agent-auth–specific surface: the registration endpoint, the claim ceremony, and the [RFC 8935](https://datatracker.ietf.org/doc/html/rfc8935) SET receiver.
 
-Advertise the identity types and assertion types your service accepts. Anonymous is the simplest if you only support self-registration; ID-JAG is for trusted-provider integrations; the verified email assertion type is for agents that have a user email but no provider-signed assertion.
+Advertise the identity types and assertion types your service accepts. Anonymous is the simplest if you only support self-registration; ID-JAG is for trusted-provider integrations; service_auth is for agents that have a user email but no provider-signed assertion. The claim ceremony is not a `/oauth2/token` grant, so `grant_types_supported` lists only the JWT-bearer exchange.
 
 On any 401 from your API, include the discovery hint:
 
@@ -209,21 +204,23 @@ Implementation steps:
 4. **Verify the signature** using the key matching `kid`.
 5. **Validate claims:** `aud` matches your auth server; `exp` is future; `iat` is not unreasonably future; `jti` has not been seen recently; `client_id` resolves to a known provider identity; at least one of `email_verified` or `phone_number_verified` is `true`; **`auth_time` is present and within `idJagMaxAuthAgeSeconds`** (see [auth_time freshness](#auth_time-freshness) below).
 6. **Match or provision the user** (see [User Matching and JIT Provisioning](#user-matching-and-jit-provisioning)). If the match resolves to an existing user via email/phone but no `(iss, sub)` delegation exists yet, step up (see [First-link step-up](#first-link-step-up) below) — do **not** silently bind.
-7. **Mint a service-signed identity_assertion** (typed `oauth-id-jag+jwt`, signed by your AS key, with `sub` = the registration ID). This is what the agent will exchange at `/oauth2/token`.
+7. **Mint a service-signed identity assertion** (typed `oauth-id-jag+jwt`, signed by your AS key, with `sub` = the registration ID). This is what the agent will exchange at `/oauth2/token`.
 
 Clean-match response:
 
 ```json
 {
-  "registration_id": "reg_...",
-  "registration_type": "identity_assertion",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z",
+  "id": "reg_...",
+  "type": "identity_assertion",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z"
+  },
   "scopes": ["api.read", "api.write"]
 }
 ```
 
-The agent then POSTs the `identity_assertion` to [`/oauth2/token`](#post-oauth2token) to obtain an access_token. No credential is issued at `/agent/identity` itself.
+The agent then POSTs `identity.assertion` to [`/oauth2/token`](#post-oauth2token) to obtain an access_token. No credential is issued at `/agent/identity` itself.
 
 Error response (400 except where noted):
 
@@ -259,28 +256,28 @@ WWW-Authenticate: AgentAuth error="interaction_required", error_description="...
 {
   "error": "interaction_required",
   "error_description": "...",
-  "registration_id": "reg_...",
-  "registration_type": "identity_assertion",
-  "claim_url": "/agent/identity/claim",
-  "claim_token": "clm_...",
-  "claim_token_expires": "...",
-  "post_claim_scopes": ["api.read", "api.write"],
+  "id": "reg_...",
+  "type": "identity_assertion",
+  "scopes": { "post_claim": ["api.read", "api.write"] },
   "claim": {
-    "user_code": "123456",
-    "expires_in": 600,
-    "verification_uri": "...",
-    "interval": 5
+    "token": "clm_...",
+    "expires_at": "...",
+    "url": "/agent/identity/claim",
+    "attempt": {
+      "verification_uri": "...",
+      "expires_at": "..."
+    }
   }
 }
 ```
 
-The `claim` block is the same shape as the verified-email and anonymous flows ([Claim Ceremony](#claim-ceremony)). The user-facing `/claim` page renders provider-aware copy for ID-JAG registrations ("**Acme** is asking to link this account…") — the provider display name comes from your trust list. After completion, the agent's next poll picks up the bound delegation. The same `(iss, sub, aud)` triple is keyed on a single registration row whether pending or bound, so repeat presentations during step-up reuse the row and re-issue a fresh ceremony.
+The `claim` block is the same shape as the service_auth and anonymous flows ([Claim Ceremony](#claim-ceremony)). The user-facing `/claim` page renders provider-aware copy for ID-JAG registrations ("**Acme** is asking to link this account…") — the provider display name comes from your trust list. After the user confirms and reads the `user_code` back, the agent submits it at `/agent/identity/claim/complete` to bind the delegation. The same `(iss, sub, aud)` triple is keyed on a single registration row whether pending or bound, so repeat presentations during step-up reuse the row and re-issue a fresh ceremony.
 
 **Why step up.** Without it, any trusted provider could mint an ID-JAG with `email_verified: true` for `victim@example.com` and silently take over that user's account at your service. Step-up gates the binding on the user being signed in at your service — their authenticated session is what authorizes the link.
 
 In production, services often source provider display names from CIMD ([Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)) instead of maintaining them by hand — the provider hosts a metadata document at a stable URL and the service fetches it. Either way, the service decides what `/claim` renders; never render a `client_name` value the provider sets directly, since a malicious provider would pick its own marketing copy.
 
-**The claim ceremony is your primary place to enforce authorization policies.** The agent never authenticates the user; the agent presents an ID-JAG (which the provider authenticated, on the provider's terms) and the service authenticates the user via its existing `/login` flow during the ceremony. Whatever conditions you normally enforce in interactive browser sign-in — enterprise SSO, MFA, bot detection, terms re-acceptance, just-in-time provisioning checks — apply here, with no agent-auth-specific exceptions. If `acme.com` is enterprise-SSO-managed in your tenant, an ID-JAG asserting `alice@acme.com` from a provider Acme should land the user on a sign-in surface that refuses to complete until Alice authenticates through Acme's IdP. The agent polls until the user finishes; from the agent's perspective the flow is identical whether the gate is "no gate," "MFA," or "full enterprise SSO." This is how ID-JAGs don't bypass your domain-bound policies.
+**The claim ceremony is your primary place to enforce authorization policies.** The agent never authenticates the user; the agent presents an ID-JAG (which the provider authenticated, on the provider's terms) and the service authenticates the user via its existing `/login` flow during the ceremony. Whatever conditions you normally enforce in interactive browser sign-in — enterprise SSO, MFA, bot detection, terms re-acceptance, just-in-time provisioning checks — apply here, with no agent-auth-specific exceptions. If `acme.com` is enterprise-SSO-managed in your tenant, an ID-JAG asserting `alice@acme.com` from a provider Acme should land the user on a sign-in surface that refuses to complete until Alice authenticates through Acme's IdP. The agent waits for the user to finish and read back the code; from the agent's perspective the flow is identical whether the gate is "no gate," "MFA," or "full enterprise SSO." This is how ID-JAGs don't bypass your domain-bound policies.
 
 #### type: anonymous
 
@@ -295,26 +292,32 @@ Implementation steps:
 1. Apply rate limits (see [Rate Limiting](#rate-limiting)).
 2. Create the registration. The principal it eventually binds to is up to the service — it might be a user, workspace, account, tenant, or organization. Flag it as agent-created so downstream events and UI can distinguish it.
 3. Generate a claim token (prefixed, high-entropy — e.g., `clm_` + 25 chars base62). Store only its SHA-256 hash. Return the plaintext exactly once.
-4. Mint a service-signed `identity_assertion` bound to the registration. At `/oauth2/token` exchange time, unclaimed anonymous registrations get the pre-claim scope set.
+4. Mint a service-signed identity assertion bound to the registration. At `/oauth2/token` exchange time, unclaimed anonymous registrations get the pre-claim scope set.
 5. Schedule an expiration job at the registration's TTL to mark the claim expired.
 
 Successful response:
 
 ```json
 {
-  "registration_id": "reg_01ABC123DEF456GHI789JKL0MN",
-  "registration_type": "anonymous",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z",
-  "pre_claim_scopes": ["api.read"],
-  "claim_url": "/agent/identity/claim",
-  "claim_token": "clm_abc123def456ghi789jkl012mno",
-  "claim_token_expires": "2026-04-22T12:34:56.789Z",
-  "post_claim_scopes": ["api.read", "api.write"]
+  "id": "reg_01ABC123DEF456GHI789JKL0MN",
+  "type": "anonymous",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z"
+  },
+  "scopes": {
+    "pre_claim": ["api.read"],
+    "post_claim": ["api.read", "api.write"]
+  },
+  "claim": {
+    "token": "clm_abc123def456ghi789jkl012mno",
+    "expires_at": "2026-04-22T12:34:56.789Z",
+    "url": "/agent/identity/claim"
+  }
 }
 ```
 
-See [Claim Ceremony](#claim-ceremony) for the `/agent/identity/claim` init and the agent's poll loop. After a successful claim the agent re-exchanges the same `identity_assertion` at `/oauth2/token` to pick up the `post_claim_scopes`.
+See [Claim Ceremony](#claim-ceremony) for the `/agent/identity/claim` init and the agent's completion call. After a successful claim the agent re-exchanges the post-claim `identity.assertion` at `/oauth2/token` to pick up the `scopes.post_claim` set. (Anonymous registrations get no pre-minted attempt — the agent starts one at `/agent/identity/claim`.)
 
 #### type: service_auth
 
@@ -330,35 +333,34 @@ Request:
 Implementation steps:
 
 1. Create a registration row marked as `service_auth` and persist the asserted email as `claim_email`.
-2. Generate a `claim_token` (returned to the agent), a `claim_attempt_token` (embedded in `verification_uri`), and a 6-digit `user_code`. Store SHA-256 hashes of all three; return the plaintext `claim_token` and `user_code` in the response, embed the `claim_attempt_token` in the `verification_uri`.
-3. Return the claim handles + a `claim` block (see [Claim Ceremony](#claim-ceremony)) — but **no identity_assertion**. The assertion is minted when the user completes the ceremony and the agent polls `/oauth2/token` with the claim grant.
+2. Generate a `claim_token` (returned to the agent), a `claim_attempt_token` (embedded in `verification_uri`), and a 6-digit `user_code`. Store SHA-256 hashes of the tokens; keep the `user_code` to reveal on the claim page later. Return the plaintext `claim_token` and embed the `claim_attempt_token` in the `verification_uri`. **The `user_code` is never returned to the agent.**
+3. Return the claim handles + a `claim` block with the first `attempt` (see [Claim Ceremony](#claim-ceremony)) — but **no identity assertion**. The assertion is minted when the agent completes the ceremony at `/agent/identity/claim/complete`.
 
 Successful response:
 
 ```json
 {
-  "registration_id": "reg_01ABC...",
-  "registration_type": "service_auth",
-  "claim_url": "/agent/identity/claim",
-  "claim_token": "clm_abc123...",
-  "claim_token_expires": "2026-04-22T12:34:56.789Z",
-  "post_claim_scopes": ["api.read", "api.write"],
+  "id": "reg_01ABC...",
+  "type": "service_auth",
+  "scopes": { "post_claim": ["api.read", "api.write"] },
   "claim": {
-    /* user_code, verification_uri, expires_in, interval */
+    "token": "clm_abc123...",
+    "expires_at": "2026-04-22T12:34:56.789Z",
+    "url": "/agent/identity/claim",
+    "attempt": {
+      /* verification_uri, expires_at — no user_code */
+    }
   }
 }
 ```
 
 ### POST /oauth2/token
 
-The token endpoint handles two grants, dispatched on `grant_type`:
-
-- `urn:ietf:params:oauth:grant-type:jwt-bearer` — agent presents a service-signed identity_assertion in exchange for an access_token. See below.
-- `urn:workos:agent-auth:grant-type:claim` — agent polls during the claim ceremony. See [Claim Ceremony → Agent poll](#post-oauth2token-claim-grant--agent-poll).
+The token endpoint handles a single grant, `urn:ietf:params:oauth:grant-type:jwt-bearer` — the agent presents a service-signed identity assertion in exchange for an access_token. The claim ceremony does **not** run through this endpoint; the agent completes it at [`/agent/identity/claim/complete`](#post-agentidentityclaimcomplete--agent-completion) and gets a refresh token for the assertion-refresh path.
 
 #### JWT-bearer grant (RFC 7523)
 
-The agent presents the service-signed identity_assertion to exchange it for an access_token. Standard [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant, form-encoded:
+The agent presents the service-signed identity assertion to exchange it for an access_token. Standard [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer grant, form-encoded:
 
 ```
 POST /oauth2/token HTTP/1.1
@@ -372,7 +374,7 @@ grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
 
 Implementation steps:
 
-1. **Parse the form-encoded body.** Validate `grant_type`; route to this handler. If the value is something else (and not the claim grant), return `unsupported_grant_type`.
+1. **Parse the form-encoded body.** Validate `grant_type`; route to this handler. Any other value returns `unsupported_grant_type`.
 2. **Verify the `assertion`** against your service's signing key. It must be `typ: "oauth-id-jag+jwt"`, with `iss` and `aud` equal to your AS, a valid `exp`, and a `sub` resolving to a registration in your store.
 3. **Look up the registration by `sub`.** If absent or expired, return `invalid_grant`.
 4. **Issue an access_token** scoped per the registration's state. Anonymous-unclaimed gets your configured pre-claim scopes; everything else gets the registration's full granted set.
@@ -388,7 +390,7 @@ Successful response (standard OAuth shape per RFC 6749 §5.1):
 }
 ```
 
-The token endpoint should never issue a `refresh_token`. The same `identity_assertion` can be re-exchanged at `/oauth2/token` to refresh the access_token until the assertion itself expires.
+The token endpoint should never issue a `refresh_token`. The same `identity.assertion` can be re-exchanged at `/oauth2/token` to refresh the access_token until the assertion itself expires; when the assertion expires, service_auth and claimed registrations mint a fresh one via [`/agent/identity` `type: refresh`](#assertion-refresh) (anonymous-pre-claim and id_jag re-register).
 
 Error response uses standard OAuth error codes (RFC 6749 §5.2):
 
@@ -396,7 +398,7 @@ Error response uses standard OAuth error codes (RFC 6749 §5.2):
 { "error": "invalid_grant", "error_description": "..." }
 ```
 
-Supported error codes: `invalid_request`, `invalid_grant`, `unsupported_grant_type` (plus the claim grant's `authorization_pending`, `slow_down`, `expired_token` from [its handler](#post-oauth2token-claim-grant--agent-poll)).
+Supported error codes: `invalid_request`, `invalid_grant`, `unsupported_grant_type`.
 
 ### POST /oauth2/revoke — RFC 7009 token revocation
 
@@ -444,131 +446,118 @@ Reject ID-JAGs with neither a verified email nor a verified phone — there's no
 
 ### Claim Ceremony
 
-Both `anonymous` and `service_auth` flows funnel into the same ceremony: the service mints a `user_code`, the agent surfaces it to the user along with a `verification_uri`, the user signs in to the service and types the code on a service-owned form, the agent polls for completion. The ceremony fields (`user_code`, `verification_uri`, `expires_in`, `interval`) borrow from [RFC 8628 device authorization](https://datatracker.ietf.org/doc/html/rfc8628), and polling happens at the standard `token_endpoint` with a profile-specific grant (`urn:workos:agent-auth:grant-type:claim`).
+Both `anonymous` and `service_auth` flows funnel into the same ceremony, and it's always the **service_auth** method (anonymous registrations are claimed via service_auth too): the agent hands the user a `verification_uri` (no code), the user signs in to the service and confirms on a service-owned page, the page **reveals** a `user_code`, the user reads it back to the agent, and the agent submits it at `/agent/identity/claim/complete`. The ceremony fields (`user_code`, `verification_uri`) borrow their shape from [RFC 8628 device authorization](https://datatracker.ietf.org/doc/html/rfc8628), but the code travels service → user → agent, so there is no polling grant and no `interval`.
 
+| Flow         | First attempt minted at                           | claim/complete returns                                                                                 |
+| ------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Anonymous    | `/agent/identity/claim` (agent starts it)         | Post-claim identity: a **v2** `identity.assertion` (the v1 was pre-claim) + a rotating `refresh_token` |
+| service_auth | `/agent/identity` (bundled under `claim.attempt`) | The first `identity.assertion` (none was issued at registration time) + a rotating `refresh_token`     |
 
-**Why a profile-specific grant URN.** Polling could in principle reuse `urn:ietf:params:oauth:grant-type:device_code`, but a service implementing standard RFC 8628 device authorization at the same token endpoint would then have to disambiguate by inspecting the bearer value (claim_token vs device_code). A custom URN routes by grant_type, which is where OAuth implementations already dispatch — no collision risk.
+#### Attempt block shape
 
-| Flow           | Ceremony block returned at                | Claim grant returns                                                                                             |
-| -------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Anonymous      | `/agent/identity/claim` (`claim_attempt`) | Standard OAuth token response + a **v2** identity_assertion (the v1 was pre-claim; v2 carries the user's email) |
-| Verified-email | `/agent/identity` (`claim`)               | Standard OAuth token response + the first identity_assertion (none was issued at registration time)             |
-
-#### Ceremony block shape
-
-Returned nested under `claim` (service_auth registration response) or `claim_attempt` (anonymous `/claim` response):
+Returned nested under `claim.attempt` (service_auth registration response) or `attempt` (the `/agent/identity/claim` response):
 
 ```json
 {
-  "user_code": "123456",
-  "expires_in": 600,
   "verification_uri": "https://auth.service.example.com/login?return_to=%2Fclaim%3Fclaim_attempt_token%3D...",
-  "interval": 5
+  "expires_at": "2026-05-04T12:10:00.000Z"
 }
 ```
 
-The `verification_uri` routes through `/login` first so the user authenticates before landing on the claim page. `claim_attempt_token` (in the return_to path) binds the URL to a specific registration — opening the URL identifies the registration without revealing the `user_code`.
+The `verification_uri` routes through `/login` first so the user authenticates before landing on the claim page. `claim_attempt_token` (in the return_to path) binds the URL to a specific registration — opening it identifies the registration without carrying the `user_code`, which the service reveals only after the user confirms. **The `user_code` is never in this block.**
 
-#### POST /agent/identity/claim — Anonymous claim entry
+#### POST /agent/identity/claim — Start (or re-mint) an attempt
 
-Anonymous-only. Verified-email registrations skip this — their `claim` block is bundled into the `/agent/identity` registration response.
+For **anonymous**, the agent calls this to start the first attempt. For **service_auth**, the first attempt is bundled into the registration response; the agent calls this only to re-mint after a `user_code` expires. Either way, `type` is `service_auth` — the claim method.
 
 Request:
 
 ```json
 {
+  "type": "service_auth",
   "claim_token": "clm_abc123...",
-  "email": "user@example.com"
+  "login_hint": "user@example.com"
 }
 ```
 
-The `email` binds the registration to the human the agent is acting for. Only that signed-in user can complete the ceremony — without this binding, a third party who intercepts the `user_code` could claim the agent on their own account.
+The `login_hint` binds the attempt to the human the agent is acting for. Only that signed-in user can complete the ceremony — without this binding, a third party who intercepts the link could claim the agent on their own account.
 
 Response (200):
 
 ```json
 {
-  "registration_id": "reg_01ABC...",
-  "claim_attempt_id": "cla_01XYZ...",
-  "status": "initiated",
-  "expires_at": "2026-05-04T12:10:00.000Z",
-  "claim_attempt": {
-    /* claim_attempt fields, see above */
+  "id": "reg_01ABC...",
+  "type": "service_auth",
+  "attempt": {
+    /* verification_uri, expires_at — see above */
   }
 }
 ```
 
-`claim_attempt_id` identifies the current claim attempt. A new identifier is minted each time a fresh attempt is initiated — including same-email retries; the previous URL stops working.
-
 Implementation notes:
 
-- Hash the incoming `claim_token` and look up the registration. Reject if not found (`invalid_claim_token`), already claimed (`claimed_or_in_flight`), or expired (`claim_expired`).
-- Record `claim_email` on the registration so the claim page can enforce the binding.
-- Mint a `claim_attempt_token` and a `user_code`; store SHA-256 hashes of both, return the plaintexts.
+- Hash the incoming `claim_token` and look up the registration. Reject if not found (`invalid_claim_token`), already claimed (`already_claimed`), or expired (`claim_expired`).
+- Record the `login_hint` on the attempt so the claim page can enforce the binding.
+- Mint a `claim_attempt_token` and a `user_code`; store the token hash and hold the `user_code` to reveal on the claim page. Return only the `verification_uri` (with the token embedded).
 - The `verification_uri` should route through your sign-in flow first (so the user authenticates before the claim page can identify them).
 
-#### User-facing claim form
+#### User-facing claim page
 
 The user opens `verification_uri`, signs in to the service, and lands on a page that:
 
 1. Resolves the registration via `claim_attempt_token` (from the URL).
-2. Verifies the signed-in user matches `registration.claim_email` if set — rejects mismatches.
-3. Renders a form that POSTs `claim_attempt_token` + the typed `user_code` to a service-owned form-action endpoint.
-4. On the form post, the service verifies the `user_code` against the registration's stored hash and marks the claim complete. Same-account check applies again on submit.
+2. Verifies the signed-in user matches the attempt's `login_hint` if set — rejects mismatches (`wrong_account`).
+3. Renders a **confirm** button (no code input). On confirm, the service binds the confirming user to the attempt and **reveals the `user_code`** for the user to read back to the agent.
 
-This is a service-owned UX surface — agents never see it.
+This is a service-owned UX surface — agents never see it. The confirm POST is a service-internal form action (`/claim/confirm` in the sample), distinct from the agent-facing `/agent/identity/claim/complete`.
 
-#### POST /oauth2/token (claim grant) — Agent poll
+#### POST /agent/identity/claim/complete — Agent completion
 
-Polling happens at the standard `token_endpoint` with a profile-specific grant. Form-encoded, as with the JWT-bearer grant:
+The agent submits its `claim_token` plus the `user_code` the user read back:
 
 ```
-POST /oauth2/token HTTP/1.1
+POST /agent/identity/claim/complete HTTP/1.1
 Host: auth.service.example.com
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
 
-grant_type=urn:workos:agent-auth:grant-type:claim
-&claim_token=<clm_...>
+{ "claim_token": "clm_...", "user_code": "123456" }
 ```
 
-While the user has not completed the ceremony (RFC 8628 §3.5 vocabulary, served via the standard OAuth error envelope):
+On success — a one-shot response carrying the post-claim identity (the assertion and a rotating refresh token):
 
 ```json
 {
-  "error": "authorization_pending",
-  "error_description": "The user has not yet completed the ceremony."
-}
-```
-
-On completion: a standard OAuth token response, extended with `identity_assertion` and `assertion_expires`:
-
-```json
-{
-  "access_token": "<post-claim access_token>",
-  "token_type": "Bearer",
-  "expires_in": 3600,
-  "scope": "api.read api.write",
-  "identity_assertion": "<service-signed JWT>",
-  "assertion_expires": "2026-05-04T13:00:00.000Z"
-}
-```
-
-When the ceremony window has closed:
-
-```json
-{
-  "error": "expired_token",
-  "error_description": "The claim ceremony window has closed."
+  "id": "reg_01ABC...",
+  "status": "claimed",
+  "identity": {
+    "assertion": "<service-signed JWT>",
+    "expires_at": "2026-05-04T13:00:00.000Z",
+    "refresh_token": {
+      "value": "art_...",
+      "expires_at": "2026-06-03T12:00:00.000Z"
+    }
+  }
 }
 ```
 
 Implementation notes:
 
-- Look up the registration by `sha256(claim_token)`. If absent → `expired_token`. If `status === "expired"` → `expired_token`. If `status !== "claimed"` → `authorization_pending`. If claimed → mint a fresh access_token and a fresh identity_assertion.
-- For **anonymous**, on completion the pre-claim access_tokens (from earlier jwt-bearer exchanges) should be **revoked** — the canonical credential is the one returned here. The v2 identity_assertion includes the now-known `email` / `email_verified` claims; the v1 the agent held has neither.
-- For **service_auth**, this is the first time an identity_assertion exists for this registration — the agent uses it for jwt-bearer refreshes once the returned access_token expires.
-- Honor RFC 8628's `interval` — return `{ "error": "slow_down" }` if the agent polls faster than advertised.
+- Look up the registration by `sha256(claim_token)`. If absent → `invalid_claim`.
+- If the attempt hasn't been confirmed by a signed-in user yet → `claim_not_confirmed` (409). The agent waits and retries.
+- If the submitted `user_code` doesn't match → `invalid_user_code` (401). If the code's window has closed → `user_code_expired` (410); the agent re-mints via `/agent/identity/claim`. If already claimed → `already_claimed` (409); if the outer window closed → `claim_expired` (410).
+- On success, bind the registration to the confirming user, mint the identity assertion (with the user's `email` / `email_verified`) and a rotating `refresh_token`, and return them once.
+- For **anonymous**, revoke the pre-claim access_tokens (from earlier jwt-bearer exchanges) — the canonical credential is minted by re-exchanging the post-claim assertion. The v2 assertion carries the now-known `email` claims; the v1 didn't.
 - Emit `claim.confirmed` (see [Recommended Audit Events](#recommended-audit-events)).
+
+#### Assertion refresh
+
+service_auth and claimed registrations hold a rotating `refresh_token` (returned by claim/complete). When the assertion nears expiry, the agent exchanges it for a fresh one at `/agent/identity`:
+
+```json
+{ "type": "refresh", "refresh_token": "art_..." }
+```
+
+The response is a registration envelope with a fresh `identity.assertion` and a new `refresh_token` (the presented one is spent). Reject a missing, expired, or already-spent token with `invalid_refresh_token`. Anonymous pre-claim and id_jag registrations have no refresh token — they re-exchange the still-valid assertion, or re-register.
 
 ### Revocation
 
@@ -625,17 +614,18 @@ Use a sliding-window counter backed by a shared store (Redis is common). Fail op
 
 Record the following state transitions for observability and incident response. How they're exposed — audit log, webhook, SIEM stream, admin API — is an implementation choice; the set of events and the data they carry is the useful baseline.
 
-| Event                  | When                                                        | Recommended fields                      |
-| ---------------------- | ----------------------------------------------------------- | --------------------------------------- |
-| `registration.created` | Any successful `/agent/identity` POST                       | `registration_id`, `registration_type`  |
-| `assertion.issued`     | A service-signed identity_assertion is minted               | `registration_id`                       |
-| `token.issued`         | `/oauth2/token` returns an access_token                     | `registration_id`, `scope`              |
-| `token.revoked`        | `/oauth2/revoke` invalidates a credential                   | `registration_id`                       |
-| `claim.requested`      | `/agent/identity/claim` called (or implicit on service_auth)       | `registration_id`, `email`              |
-| `user_code.minted`     | user_code minted at ceremony start                          | `registration_id`                       |
-| `claim.confirmed`      | `/agent/identity/claim/complete` succeeds                   | `registration_id`, `claimed_by_user_id` |
-| `registration.expired` | Unclaimed registration past its TTL                         | `registration_id`                       |
-| `registration.revoked` | SET processed at `/agent/event/notify`                      | `registration_id`, `iss`, `sub`         |
+| Event                  | When                                                         | Recommended fields                        |
+| ---------------------- | ------------------------------------------------------------ | ----------------------------------------- |
+| `registration.created` | Any successful `/agent/identity` POST                        | `registration_id`, `type`                 |
+| `assertion.issued`     | A service-signed identity assertion is minted                | `registration_id`                         |
+| `token.issued`         | `/oauth2/token` returns an access_token                      | `registration_id`, `scope`                |
+| `token.revoked`        | `/oauth2/revoke` invalidates a credential                    | `registration_id`                         |
+| `claim.requested`      | `/agent/identity/claim` called (or implicit on service_auth) | `registration_id`, `login_hint`           |
+| `user_code.revealed`   | user_code revealed to the confirming user on the claim page  | `registration_id`, `confirmed_by_user_id` |
+| `claim.confirmed`      | `/agent/identity/claim/complete` succeeds                    | `registration_id`, `claimed_by_user_id`   |
+| `assertion.refreshed`  | `/agent/identity` (`type: refresh`) rotates the assertion    | `registration_id`                         |
+| `registration.expired` | Unclaimed registration past its TTL                          | `registration_id`                         |
+| `registration.revoked` | SET processed at `/agent/event/notify`                       | `registration_id`, `iss`, `sub`           |
 
 For ID-JAG flows, include `iss`, `sub`, `agent_platform`, and `agent_context_id` so operators can correlate with provider-side logs.
 
@@ -643,10 +633,12 @@ Services that already expose resource events (for API keys, invitations, members
 
 ## Security Considerations
 
-- **Token hashing.** The `claim_token`, `claim_attempt_token`, and `user_code` are all bearer secrets with no proof of possession — store only SHA-256 hashes. Plaintext leaves the server exactly once: claim_token + user_code in the ceremony response to the agent, claim_attempt_token inside the `verification_uri` query string.
-- **user_code entropy + TTL.** Use a CSPRNG (`crypto.randomInt`) for the `user_code`. Default to a short TTL (≤10 min) and tight per-claim retry limits at the `/claim` form-action — 6-digit codes are guess-bounded only by lockout, not entropy.
-- **IP logging.** Capture IPs at registration, claim, and complete for audit trail.
-- **Scope on /claim and /complete.** Both endpoints are public but must resolve to a tenant / environment, and reject tokens that don't belong to that scope even if the hash somehow collides.
+- **Token hashing.** The `claim_token` and `claim_attempt_token` are bearer secrets with no proof of possession — store only SHA-256 hashes. The `user_code` is held server-side and revealed on the claim page only after the user confirms. Plaintext leaves the server as: `claim_token` in the registration response to the agent, `claim_attempt_token` inside the `verification_uri` query string, and `user_code` on the claim page to the confirmed user (who relays it back to the agent). The agent submits `claim_token` + `user_code` at claim/complete.
+- **user_code entropy + TTL.** Use a CSPRNG (`crypto.randomInt`) for the `user_code`. Default to a short TTL (≤10 min) and tight per-registration retry limits at `/agent/identity/claim/complete` — 6-digit codes are guess-bounded only by lockout, not entropy. Requiring the attempt to be confirmed by a signed-in user before any code is accepted removes the pre-confirmation guessing window entirely.
+- **Confirm before reveal.** Only reveal the `user_code` after the signed-in user matches the attempt's `login_hint` and confirms. This is what binds the ceremony to the intended human — an intercepted `verification_uri` lands a third party on a page that won't reveal a code for someone else's `login_hint`.
+- **IP logging.** Capture IPs at registration, claim start, confirm, and complete for audit trail.
+- **Scope on claim endpoints.** The claim, confirm, and complete endpoints must resolve to a tenant / environment, and reject tokens that don't belong to that scope even if the hash somehow collides.
+- **Refresh-token rotation.** Rotate the `refresh_token` on every exchange and reject a presented-but-spent token (a reuse signal). Store only its hash.
 - **Key reuse across the claim boundary.** For anonymous, the in-place permission swap means anyone who captured the API key pre-claim retains access post-claim with the new scopes. Offer forced rotation as an opt-in for security-sensitive tenants.
 - **Bulk revocation.** Provide an operator-facing mechanism to revoke all outstanding agent credentials for a tenant in one shot — for incident response.
 - **Assertion replay.** Cache `jti` values for at least the assertion lifetime plus clock skew. A shared store is required if `/agent/identity` runs across multiple replicas.

--- a/agent-services/package.json
+++ b/agent-services/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "NODE_ENV=development tsx watch src/index.ts",
     "build": "tsc -p .",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit"

--- a/agent-services/src/config.ts
+++ b/agent-services/src/config.ts
@@ -27,6 +27,13 @@ export const config = Object.freeze({
    * within this window; when it expires, the agent re-calls /agent/identity.
    */
   serviceAssertionTtlSeconds: 3600,
+  /**
+   * Lifetime of the rotating refresh token issued to service_auth and claimed
+   * registrations at claim/complete. Longer than the assertion — it's how the
+   * agent mints a fresh assertion once the current one expires, via
+   * /agent/identity (type: refresh).
+   */
+  refreshTokenTtlSeconds: 30 * 86400,
   anonymousTtlSeconds: 86400,
   /**
    * Maximum age of the upstream user authentication carried in an ID-JAG's
@@ -36,10 +43,8 @@ export const config = Object.freeze({
    */
   idJagMaxAuthAgeSeconds: 3600,
   claimViewTokenTtlSeconds: 600,
-  /** Lifetime of the user_code minted at ceremony start (RFC 8628). */
+  /** Lifetime of the user_code revealed on the claim page (RFC 8628 shape). */
   userCodeTtlSeconds: 600,
-  /** Recommended agent poll cadence (RFC 8628 `interval`). */
-  pollIntervalSeconds: 5,
   /** Lifetime of the cookie-bound session minted at /login. */
   sessionTtlSeconds: 86400,
   /**

--- a/agent-services/src/routes/agent-auth.ts
+++ b/agent-services/src/routes/agent-auth.ts
@@ -1,17 +1,26 @@
 import express, { Router } from "express";
 import { config } from "../config.js";
 import { matchOrProvision } from "../matcher.js";
-import { agentAuthBody, claimBody, parseBody } from "../schemas.js";
+import {
+  agentAuthBody,
+  claimBody,
+  claimCompleteBody,
+  parseBody,
+} from "../schemas.js";
 import {
   type Registration,
   classifyLoginHint,
+  completeClaimByAgent,
   createAnonymousRegistration,
   createServiceAuthRegistration,
   findOrCreateIdJagRegistration,
   findRegistrationByClaimHash,
+  mintRefreshToken,
   recordClaimAttempt,
   revokeForDelegation,
+  rotateRefreshToken,
   sha256Hex,
+  users,
 } from "../store.js";
 import {
   type IdJagClaims,
@@ -22,14 +31,14 @@ import {
 } from "../verify.js";
 
 /*
- * Agent-facing endpoints. The user-facing claim ceremony — the page where
- * the user signs in and types the user_code — lives in routes/login.ts and
- * routes/claim.ts. The agent never reaches those; it polls /oauth2/token
- * with the claim grant (urn:workos:agent-auth:grant-type:claim).
+ * Agent-facing endpoints. The user-facing claim page — where the human signs
+ * in, confirms, and reads back the user_code the page reveals — lives in
+ * routes/login.ts and routes/claim.ts. The agent never reaches those; it
+ * completes the ceremony by submitting that code at claim/complete.
  *
  * Three response shapes from POST /agent/identity for ID-JAG flows:
- *   - clean match → 200 with identity_assertion
- *   - step-up required → 401 interaction_required with ceremony block
+ *   - clean match → 200 with an identity assertion
+ *   - step-up required → 401 interaction_required with a claim block
  *   - login_required → 401 login_required (auth_time missing or stale;
  *     agent re-mints upstream)
  */
@@ -49,6 +58,9 @@ agentAuthRouter.post(config.identityEndpointPath, async (req, res) => {
   if (parsed.value.type === "service_auth") {
     return handleServiceAuth(parsed.value, res);
   }
+  if (parsed.value.type === "refresh") {
+    return handleRefresh(parsed.value, res);
+  }
 
   const { registration, claimTokenPlaintext } = createAnonymousRegistration();
   const { jwt, expiresAt } = await signServiceIdJag({ registration });
@@ -56,17 +68,61 @@ agentAuthRouter.post(config.identityEndpointPath, async (req, res) => {
     `[agent-auth] registered anonymous agent registration=${registration.id}`,
   );
   res.json({
-    registration_id: registration.id,
-    registration_type: "anonymous",
-    identity_assertion: jwt,
-    assertion_expires: expiresAt.toISOString(),
-    pre_claim_scopes: config.preClaimScopes,
-    claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
-    claim_token: claimTokenPlaintext,
-    claim_token_expires: registration.claim!.expires_at.toISOString(),
-    post_claim_scopes: config.postClaimScopes,
+    id: registration.id,
+    type: "anonymous",
+    identity: { assertion: jwt, expires_at: expiresAt.toISOString() },
+    scopes: {
+      pre_claim: config.preClaimScopes,
+      post_claim: config.postClaimScopes,
+    },
+    claim: {
+      token: claimTokenPlaintext,
+      expires_at: registration.claim!.expires_at.toISOString(),
+      url: `${config.baseUrl}${config.claimEndpointPath}`,
+    },
   });
 });
+
+/**
+ * Exchanges a rotating refresh token for a fresh identity assertion (and a
+ * new refresh token). Only service_auth and claimed registrations hold one.
+ */
+async function handleRefresh(
+  body: { refresh_token: string },
+  res: express.Response,
+): Promise<void> {
+  const rotated = rotateRefreshToken(body.refresh_token);
+  if (!rotated.ok) {
+    res.status(400).json({
+      error: "invalid_refresh_token",
+      message: "The refresh token is invalid, expired, or already used.",
+    });
+    return;
+  }
+  const user = rotated.registration.user_id
+    ? users.get(rotated.registration.user_id)
+    : undefined;
+  const { jwt, expiresAt } = await signServiceIdJag({
+    registration: rotated.registration,
+    email: user?.email,
+    emailVerified: user?.email_verified,
+  });
+  console.log(
+    `[agent-auth] refreshed identity assertion for registration=${rotated.registration.id}`,
+  );
+  res.json({
+    id: rotated.registration.id,
+    type: "refresh",
+    identity: {
+      assertion: jwt,
+      expires_at: expiresAt.toISOString(),
+      refresh_token: {
+        value: rotated.value,
+        expires_at: rotated.expiresAt.toISOString(),
+      },
+    },
+  });
+}
 
 async function handleIdJagAssertion(
   body: { assertion: string },
@@ -111,13 +167,12 @@ async function emitIdJagSuccess(
     amr: claims.amr,
   });
   console.log(
-    `[agent-auth] issued identity_assertion to user=${registration.user_id} via iss=${claims.iss} sub=${claims.sub} registration=${registration.id}`,
+    `[agent-auth] issued identity assertion to user=${registration.user_id} via iss=${claims.iss} sub=${claims.sub} registration=${registration.id}`,
   );
   res.json({
-    registration_id: registration.id,
-    registration_type: "identity_assertion",
-    identity_assertion: jwt,
-    assertion_expires: expiresAt.toISOString(),
+    id: registration.id,
+    type: "identity_assertion",
+    identity: { assertion: jwt, expires_at: expiresAt.toISOString() },
     scopes: config.scopesSupported,
   });
 }
@@ -126,9 +181,10 @@ async function emitIdJagSuccess(
  * Step-up: the ID-JAG matched an existing account by email/phone but no
  * (iss, sub) delegation exists. Mint the ceremony and return a 401 with
  * the OIDC-vocabulary `interaction_required` error so the agent knows to
- * surface the user_code + verification_uri to the user. The user signs in
- * at the service, sees a provider-aware confirmation page, types the code,
- * and the next agent poll picks up the bound delegation.
+ * surface the verification_uri to the user. The user signs in at the
+ * service, sees a provider-aware confirmation page, and confirms; the page
+ * reveals the user_code for them to read back, and the agent submits it at
+ * claim/complete to bind the delegation.
  */
 async function handleIdJagStepUp(
   claims: IdJagClaims,
@@ -163,18 +219,15 @@ async function handleIdJagStepUp(
     .json({
       error: "interaction_required",
       error_description:
-        "This ID-JAG matches an existing account. Surface the user_code + verification_uri so the user can confirm linking the provider identity to their account.",
-      registration_id: result.registration.id,
-      registration_type: "identity_assertion",
-      claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
-      claim_token: result.claimTokenPlaintext,
-      claim_token_expires: result.registration.claim!.expires_at.toISOString(),
-      post_claim_scopes: config.scopesSupported,
-      claim: buildCeremonyBlock({
-        claimViewTokenPlaintext: result.claimViewTokenPlaintext,
-        userCode: result.userCode,
-        userCodeExpiresAt: result.userCodeExpiresAt,
-      }),
+        "This ID-JAG matches an existing account. Hand the verification_uri to the user; they confirm and read back a user_code for you to submit at claim/complete.",
+      id: result.registration.id,
+      type: "identity_assertion",
+      scopes: { post_claim: config.scopesSupported },
+      claim: buildClaimBlock(
+        result.registration,
+        result.claimTokenPlaintext,
+        result.claimViewTokenPlaintext,
+      ),
     });
 }
 
@@ -226,39 +279,33 @@ async function handleServiceAuth(
     return;
   }
 
-  const {
-    registration,
-    claimTokenPlaintext,
-    claimViewTokenPlaintext,
-    userCode,
-    userCodeExpiresAt,
-  } = createServiceAuthRegistration({ login_hint });
+  const { registration, claimTokenPlaintext, claimViewTokenPlaintext } =
+    createServiceAuthRegistration({ login_hint });
 
   console.log(
     `[agent-auth] service_auth registration=${registration.id} login_hint=${login_hint.value}`,
   );
 
   res.json({
-    registration_id: registration.id,
-    registration_type: "service_auth",
-    claim_url: `${config.baseUrl}${config.claimEndpointPath}`,
-    claim_token: claimTokenPlaintext,
-    claim_token_expires: registration.claim!.expires_at.toISOString(),
-    post_claim_scopes: config.postClaimScopes,
-    claim: buildCeremonyBlock({
+    id: registration.id,
+    type: "service_auth",
+    scopes: { post_claim: config.postClaimScopes },
+    claim: buildClaimBlock(
+      registration,
+      claimTokenPlaintext,
       claimViewTokenPlaintext,
-      userCode,
-      userCodeExpiresAt,
-    }),
+    ),
   });
 }
 
 /*
- * Initiates or re-mints a claim ceremony. Two registration kinds reach here:
- *   - anonymous: first initiation (binds the email) or refresh (after the
- *     user_code window closed before the user could complete).
- *   - service_auth: refresh only (the initial ceremony was minted at
- *     /agent/identity); the supplied email must match the registration.
+ * Starts (or re-mints) a claim attempt. `type` is always service_auth — the
+ * claim method — even for anonymous registrations. Two registration kinds
+ * reach here:
+ *   - anonymous: first initiation (binds the email) or a re-mint after the
+ *     user_code window closed before the user could complete.
+ *   - service_auth: re-mint only (the initial attempt was minted at
+ *     /agent/identity); the supplied login_hint may correct the email.
  */
 agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   const parsed = parseBody(claimBody, req.body);
@@ -284,59 +331,169 @@ agentAuthRouter.post(config.claimEndpointPath, async (req, res) => {
   }
   if (registration.status === "claimed") {
     res.status(409).json({
-      error: "claimed_or_in_flight",
+      error: "already_claimed",
       message: "This registration has already been claimed.",
     });
     return;
   }
   /*
-   * Mint a fresh ceremony (new claim_attempt_token + new user_code). The
+   * Mint a fresh attempt (new claim_attempt_token + new user_code). The
    * login_hint is per-attempt — a re-initiation may supply a corrected
    * email; only the current attempt's view_token and user_code work, and
    * the /claim page surfaces the current attempt's hint as an advisory.
    */
   const fresh = recordClaimAttempt(registration, {
     kind: "email",
-    value: parsed.value.email,
+    value: parsed.value.login_hint,
   });
-  const attempt = registration.claim!.attempt!;
 
   console.log(
-    `[agent-auth] claim initiated for registration=${registration.id} to=${parsed.value.email}`,
+    `[agent-auth] claim attempt started for registration=${registration.id} to=${parsed.value.login_hint}`,
   );
 
   res.json({
-    registration_id: registration.id,
-    claim_attempt_id: attempt.id,
-    status: "initiated",
-    expires_at: attempt.view_expires_at.toISOString(),
-    claim_attempt: buildCeremonyBlock({
-      claimViewTokenPlaintext: fresh.claimViewTokenPlaintext,
-      userCode: fresh.userCode,
-      userCodeExpiresAt: fresh.userCodeExpiresAt,
-    }),
+    id: registration.id,
+    type: "service_auth",
+    attempt: buildAttemptBlock(registration, fresh.claimViewTokenPlaintext),
   });
 });
 
 /*
- * Polling moved to /oauth2/token with grant_type=urn:workos:agent-auth:
- * grant-type:claim. The agent posts its claim_token there; while pending
- * the response is { error: "authorization_pending" }, on completion the
- * standard token response is returned plus an `identity_assertion`
- * extension so the agent has a refresh path via jwt-bearer. See
- * routes/token.ts.
+ * Agent-facing claim completion. The agent submits its claim_token plus the
+ * user_code the human read off the claim page. On success it collects the
+ * post-claim identity — a service-signed assertion plus a rotating refresh
+ * token — as a one-shot response. The user-facing confirmation happens
+ * separately, on the /claim page (routes/claim.ts).
  */
+agentAuthRouter.post(
+  `${config.claimEndpointPath}/complete`,
+  async (req, res) => {
+    const parsed = parseBody(claimCompleteBody, req.body);
+    if (!parsed.ok) {
+      res
+        .status(400)
+        .json({ error: "invalid_request", message: parsed.message });
+      return;
+    }
+    const registration = findRegistrationByClaimHash(
+      sha256Hex(parsed.value.claim_token),
+    );
+    if (!registration) {
+      res.status(400).json({
+        error: "invalid_claim",
+        message: "The claim attempt is invalid.",
+      });
+      return;
+    }
 
-function buildCeremonyBlock(input: {
-  claimViewTokenPlaintext: string;
-  userCode: string;
-  userCodeExpiresAt: Date;
-}): Record<string, unknown> {
+    const result = completeClaimByAgent(registration, parsed.value.user_code);
+    if (!result.ok) {
+      const { status, error, message } = completeErrorResponse(result.error);
+      res.status(status).json({ error, message });
+      return;
+    }
+
+    const { jwt, expiresAt } = await signServiceIdJag({
+      registration: result.registration,
+      email: result.user.email,
+      emailVerified: result.user.email_verified,
+    });
+    const refreshToken = mintRefreshToken(result.registration.id);
+
+    console.log(
+      `[agent-auth] claim completed for registration=${result.registration.id} by user=${result.user.id}`,
+    );
+
+    res.json({
+      id: result.registration.id,
+      status: result.registration.status,
+      identity: {
+        assertion: jwt,
+        expires_at: expiresAt.toISOString(),
+        refresh_token: {
+          value: refreshToken.value,
+          expires_at: refreshToken.expiresAt.toISOString(),
+        },
+      },
+    });
+  },
+);
+
+function completeErrorResponse(
+  error:
+    | "not_confirmed"
+    | "user_code_invalid"
+    | "user_code_expired"
+    | "previously_claimed"
+    | "claim_expired",
+): { status: number; error: string; message: string } {
+  switch (error) {
+    case "not_confirmed":
+      return {
+        status: 409,
+        error: "claim_not_confirmed",
+        message:
+          "The user hasn't confirmed on the verification page yet. Wait and retry.",
+      };
+    case "user_code_invalid":
+      return {
+        status: 401,
+        error: "invalid_user_code",
+        message: "The user_code is invalid. Ask the user to read it again.",
+      };
+    case "user_code_expired":
+      return {
+        status: 410,
+        error: "user_code_expired",
+        message:
+          "The user_code has expired. Start a new attempt at the claim endpoint.",
+      };
+    case "previously_claimed":
+      return {
+        status: 409,
+        error: "already_claimed",
+        message: "This registration has already been claimed.",
+      };
+    case "claim_expired":
+      return {
+        status: 410,
+        error: "claim_expired",
+        message: "The claim has expired. Re-register.",
+      };
+  }
+}
+
+/*
+ * The claim block returned with a registration: the agent's claim token,
+ * the window, the claim endpoint URL, and the first attempt's user-facing
+ * verification_uri. The user_code is never here — it's revealed on the
+ * claim page for the user to read back.
+ */
+function buildClaimBlock(
+  registration: Registration,
+  claimTokenPlaintext: string,
+  viewToken: string,
+): Record<string, unknown> {
   return {
-    user_code: input.userCode,
-    expires_in: secondsUntil(input.userCodeExpiresAt),
-    verification_uri: buildVerificationUri(input.claimViewTokenPlaintext),
-    interval: config.pollIntervalSeconds,
+    token: claimTokenPlaintext,
+    expires_at: registration.claim!.expires_at.toISOString(),
+    url: `${config.baseUrl}${config.claimEndpointPath}`,
+    attempt: buildAttemptBlock(registration, viewToken),
+  };
+}
+
+/*
+ * The user-facing attempt block: the verification_uri (with the view token
+ * embedded) and its window. The user_code is never here.
+ */
+function buildAttemptBlock(
+  registration: Registration,
+  viewToken: string,
+): Record<string, unknown> {
+  const attempt = registration.claim!.attempt!;
+  return {
+    verification_uri: buildVerificationUri(viewToken),
+    expires_at: attempt.view_expires_at.toISOString(),
   };
 }
 
@@ -348,10 +505,6 @@ function buildCeremonyBlock(input: {
 function buildVerificationUri(claimAttemptToken: string): string {
   const claimPath = `/claim?claim_attempt_token=${encodeURIComponent(claimAttemptToken)}`;
   return `${config.baseUrl}/login?return_to=${encodeURIComponent(claimPath)}`;
-}
-
-function secondsUntil(when: Date): number {
-  return Math.max(0, Math.floor((when.getTime() - Date.now()) / 1000));
 }
 
 /*

--- a/agent-services/src/routes/claim.ts
+++ b/agent-services/src/routes/claim.ts
@@ -1,11 +1,11 @@
 import type { Request, Response } from "express";
 import { Router } from "express";
 import { config } from "../config.js";
-import { claimFormBody, parseBody } from "../schemas.js";
+import { claimConfirmFormBody, parseBody } from "../schemas.js";
 import {
   type Registration,
   type User,
-  completeClaim,
+  confirmClaimView,
   delegations,
   findRegistrationByClaimViewHash,
   registrations,
@@ -15,13 +15,15 @@ import {
 import { trustedIssuerDisplayName } from "../trust.js";
 
 /*
- * User-facing claim form. Cookie-gated by /login. The agent never reaches
- * this code — it polls /oauth2/token with
- * grant_type=urn:workos:agent-auth:grant-type:claim for the resulting status.
+ * User-facing claim page. Cookie-gated by /login. The agent never reaches
+ * this code — it completes the ceremony by submitting, at claim/complete, the
+ * user_code this page reveals to the signed-in human.
  *
  * The query parameter `claim_attempt_token` (an extension to RFC 8628's
  * verification URL) identifies which registration this page is for, without
- * leaking the user-typed `user_code` into link previews or browser history.
+ * leaking the user_code into link previews or browser history. The user_code
+ * itself travels service → user → agent: revealed here, read back by the
+ * human, submitted by the agent.
  */
 
 export const claimRouter = Router();
@@ -35,6 +37,114 @@ claimRouter.get("/claim", (req, res) => {
   if (!user) return;
 
   const registration = lookupRegistration(token);
+  const gate = gateRegistration(registration, res);
+  if (!gate) return;
+
+  if (hintMismatch(gate.claim!.attempt!.login_hint, user)) {
+    res
+      .status(403)
+      .type("html")
+      .send(renderWrongAccount(gate.claim!.attempt!.login_hint!));
+    return;
+  }
+
+  res.type("html").send(
+    renderClaimPage({
+      status: "form",
+      title: "Authorize this agent?",
+      message: `You're signed in as <code>${escapeHtml(user.email)}</code>. Authorize this agent to act on your behalf — you'll then get a 6-digit code to read back to it.`,
+      advisories: computeAdvisories(gate, user),
+      claimAttemptToken: token,
+    }),
+  );
+});
+
+/*
+ * Confirmation endpoint. The signed-in human confirms; we bind them to the
+ * attempt and reveal the user_code for them to read back to the agent. No
+ * code is typed here — it travels service → user → agent.
+ */
+claimRouter.post("/claim/confirm", (req, res) => {
+  const parsed = parseBody(claimConfirmFormBody, req.body);
+  if (!parsed.ok) {
+    res
+      .status(400)
+      .type("html")
+      .send(
+        renderClaimPage({
+          status: "error",
+          title: "Invalid submission",
+          message: parsed.message,
+        }),
+      );
+    return;
+  }
+
+  const user = requireUser(
+    req,
+    res,
+    returnToFor(parsed.value.claim_attempt_token),
+  );
+  if (!user) return;
+
+  const registration = lookupRegistration(parsed.value.claim_attempt_token);
+  const gate = gateRegistration(registration, res);
+  if (!gate) return;
+
+  const hint = gate.claim!.attempt!.login_hint;
+  if (hintMismatch(hint, user)) {
+    res.status(403).type("html").send(renderWrongAccount(hint!));
+    return;
+  }
+
+  const result = confirmClaimView(gate, user);
+  if (!result.ok) {
+    res
+      .status(result.error === "previously_claimed" ? 409 : 410)
+      .type("html")
+      .send(
+        renderClaimPage({
+          status: "error",
+          title:
+            result.error === "previously_claimed"
+              ? "Already claimed"
+              : "Link expired",
+          message:
+            result.error === "previously_claimed"
+              ? "This registration has already been claimed. You can close this tab."
+              : "This claim link has expired. Ask the agent to start a new claim.",
+        }),
+      );
+    return;
+  }
+
+  console.log(
+    `[claim] registration=${gate.id} confirmed by user=${user.id}; user_code revealed`,
+  );
+
+  res
+    .status(200)
+    .type("html")
+    .send(
+      renderClaimPage({
+        status: "reveal",
+        title: "Read this code back to the agent",
+        message:
+          "Give this 6-digit code to the agent that sent you here. It submits the code to finish — you don't type it anywhere.",
+        userCode: result.userCode,
+      }),
+    );
+});
+
+/*
+ * Shared gate for both the page and the confirm action: resolves the
+ * registration or renders the right terminal HTML (invalid / claimed /
+ * expired). Returns the registration only when it's live and has an attempt.
+ */
+function gateRegistration(
+  registration: Registration | undefined,
+  res: Response,
+): Registration | undefined {
   if (!registration) {
     res
       .status(404)
@@ -47,7 +157,7 @@ claimRouter.get("/claim", (req, res) => {
             "This claim link is no longer valid — it may have been superseded, used, or expired. Ask the agent to start a new claim.",
         }),
       );
-    return;
+    return undefined;
   }
   if (registration.status === "claimed") {
     res
@@ -61,7 +171,7 @@ claimRouter.get("/claim", (req, res) => {
             "This registration has already been claimed. You can close this tab.",
         }),
       );
-    return;
+    return undefined;
   }
   const attempt = registration.claim?.attempt;
   if (!attempt || attempt.view_expires_at.getTime() < Date.now()) {
@@ -76,44 +186,28 @@ claimRouter.get("/claim", (req, res) => {
             "This claim link has expired. Ask the agent to start a new claim.",
         }),
       );
-    return;
+    return undefined;
   }
-  if (hintMismatch(attempt.login_hint, user)) {
-    res.status(403).type("html").send(renderWrongAccount(attempt.login_hint!));
-    return;
-  }
-
-  res.type("html").send(
-    renderClaimPage({
-      status: "form",
-      title: "Authorize this agent?",
-      message: `You're signed in as <code>${escapeHtml(user.email)}</code>. The agent should have shown you a 6-digit code — enter it below to authorize it to act on your behalf.`,
-      advisories: computeAdvisories(registration, user),
-      claimAttemptToken: token,
-    }),
-  );
-});
+  return registration;
+}
 
 /*
- * Advisories surface above the form. They don't block — typing the code is
- * still the confirm action — but each one names a thing the user should
- * notice before authorizing: the first time any agent is being linked to
- * this account, or the first time a particular provider (ID-JAG iss) is
- * being linked.
+ * Advisories surface above the confirm button. They don't block — confirming
+ * is still the action — but each one names a thing the user should notice
+ * before authorizing: the first time any agent is being linked to this
+ * account, or the first time a particular provider (ID-JAG iss) is being
+ * linked.
  *
  * Wrong-account is *not* an advisory: a login_hint that doesn't match the
- * signed-in user is a hard reject upstream of this function — the form
- * never renders in that case. Provider name comes from the service's trust
- * list, never from anything the provider supplies in the ID-JAG.
+ * signed-in user is a hard reject upstream of this function — the page never
+ * renders in that case. Provider name comes from the service's trust list,
+ * never from anything the provider supplies in the ID-JAG.
  */
 type Advisory =
   | { kind: "first_time_account"; userEmail: string }
   | { kind: "first_time_provider"; providerName: string; userEmail: string };
 
-function computeAdvisories(
-  registration: Registration,
-  user: User,
-): Advisory[] {
+function computeAdvisories(registration: Registration, user: User): Advisory[] {
   const out: Advisory[] = [];
 
   if (registration.kind === "id_jag" && registration.id_jag) {
@@ -175,91 +269,6 @@ function renderWrongAccount(hint: { kind: "email"; value: string }): string {
   });
 }
 
-/*
- * Form-action endpoint. Same path the agent used to call in the old flow,
- * but the body and auth context are different: cookie-gated, with the user
- * supplying the user_code they got from the agent.
- */
-claimRouter.post(`${config.claimEndpointPath}/complete`, (req, res) => {
-  const parsed = parseBody(claimFormBody, req.body);
-  if (!parsed.ok) {
-    res
-      .status(400)
-      .type("html")
-      .send(
-        renderClaimPage({
-          status: "error",
-          title: "Invalid submission",
-          message: parsed.message,
-        }),
-      );
-    return;
-  }
-
-  const user = requireUser(
-    req,
-    res,
-    returnToFor(parsed.value.claim_attempt_token),
-  );
-  if (!user) return;
-
-  const registration = lookupRegistration(parsed.value.claim_attempt_token);
-  if (!registration) {
-    res
-      .status(404)
-      .type("html")
-      .send(
-        renderClaimPage({
-          status: "error",
-          title: "Link invalid",
-          message:
-            "This claim link is no longer valid. Ask the agent to start a new claim.",
-        }),
-      );
-    return;
-  }
-
-  const hint = registration.claim?.attempt?.login_hint;
-  if (hintMismatch(hint, user)) {
-    res.status(403).type("html").send(renderWrongAccount(hint!));
-    return;
-  }
-
-  const result = completeClaim(registration, parsed.value.user_code, user);
-  if (!result.ok) {
-    res
-      .status(statusForError(result.error))
-      .type("html")
-      .send(
-        renderClaimPage({
-          status: "form-error",
-          title: "Authorize this agent?",
-          message: `You're signed in as <code>${escapeHtml(user.email)}</code>. The agent should have shown you a 6-digit code — enter it below to authorize it to act on your behalf.`,
-          advisories: computeAdvisories(registration, user),
-          claimAttemptToken: parsed.value.claim_attempt_token,
-          error: humanError(result.error),
-        }),
-      );
-    return;
-  }
-
-  console.log(
-    `[claim] registration=${result.registration.id} claimed by user=${user.id}`,
-  );
-
-  res
-    .status(200)
-    .type("html")
-    .send(
-      renderClaimPage({
-        status: "done",
-        title: "All set",
-        message:
-          "The agent has been authorized to act on your behalf. You can close this tab — the agent will pick up automatically.",
-      }),
-    );
-});
-
 function requireUser(
   req: Request,
   res: Response,
@@ -282,42 +291,13 @@ function returnToFor(token: string): string {
   return `/claim?claim_attempt_token=${encodeURIComponent(token)}`;
 }
 
-function statusForError(error: string): number {
-  switch (error) {
-    case "user_code_invalid":
-      return 401;
-    case "user_code_expired":
-    case "claim_expired":
-      return 410;
-    case "previously_claimed":
-      return 409;
-    default:
-      return 400;
-  }
-}
-
-function humanError(error: string): string {
-  switch (error) {
-    case "user_code_invalid":
-      return "That code doesn't match. Check the digits and try again.";
-    case "user_code_expired":
-      return "That code has expired. Ask the agent for a fresh code.";
-    case "claim_expired":
-      return "This claim has expired. Ask the agent to start a new one.";
-    case "previously_claimed":
-      return "This registration has already been claimed.";
-    default:
-      return error;
-  }
-}
-
 function renderClaimPage(input: {
-  status: "form" | "form-error" | "done" | "error";
+  status: "form" | "reveal" | "done" | "error";
   title: string;
   message: string;
   advisories?: Advisory[];
   claimAttemptToken?: string;
-  error?: string;
+  userCode?: string;
 }): string {
   const isError = input.status === "error";
   const headingColor = isError ? "var(--error)" : "var(--brand-primary)";
@@ -327,28 +307,21 @@ function renderClaimPage(input: {
     .join("\n");
 
   const formBlock =
-    input.status === "form" || input.status === "form-error"
+    input.status === "form"
       ? `
-<form method="POST" action="${config.claimEndpointPath}/complete">
+<form method="POST" action="/claim/confirm">
   <input type="hidden" name="claim_attempt_token" value="${escapeAttr(input.claimAttemptToken ?? "")}">
-  <label>
-    6-digit code
-    <input
-      type="text"
-      name="user_code"
-      inputmode="numeric"
-      pattern="[0-9]{6}"
-      maxlength="6"
-      autocomplete="one-time-code"
-      placeholder="000000"
-      required
-      autofocus
-    >
-  </label>
-  ${input.error ? `<p class="err">${escapeHtml(input.error)}</p>` : ""}
   <button type="submit">Authorize agent</button>
 </form>
-<p class="warn">Only enter a code from an agent you trust. Pasting a code from an untrusted source could let that agent act on your behalf.</p>
+<p class="warn">Only authorize an agent you started this from. Confirming reveals a code that lets that agent act on your behalf.</p>
+`
+      : "";
+
+  const codeBlock =
+    input.status === "reveal" && input.userCode
+      ? `
+<div class="code">${escapeHtml(input.userCode)}</div>
+<p class="warn">Read this code back to the agent that sent you here. Don't share it with anyone else.</p>
 `
       : "";
 
@@ -375,11 +348,9 @@ function renderClaimPage(input: {
   p { color: var(--muted); }
   code { background: var(--surface-soft); padding: .05rem .3rem; border-radius: .2rem; font-size: .9em; }
   form { margin-top: 1.5rem; display: flex; flex-direction: column; gap: .75rem; }
-  label { font-size: .85rem; font-weight: 600; color: var(--brand-text); }
-  input { width: 100%; padding: .65rem .75rem; border: 1px solid var(--border); border-radius: .35rem; font-size: 1.4rem; letter-spacing: .35rem; font-family: ui-monospace, "SF Mono", Menlo, monospace; text-align: center; background: var(--brand-bg); color: var(--brand-text); }
   button { padding: .7rem 1rem; background: var(--brand-primary); color: white; border: none; border-radius: .35rem; font-weight: 600; font-size: 1rem; cursor: pointer; }
   button:hover { filter: brightness(1.08); }
-  .err { color: var(--error); background: rgba(229, 80, 57, .08); border: 1px solid rgba(229, 80, 57, .35); padding: .5rem .75rem; border-radius: .35rem; font-size: .85rem; margin: 0; }
+  .code { margin: 1.5rem 0 .5rem; padding: 1rem; text-align: center; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 2.4rem; letter-spacing: .5rem; background: var(--surface-soft); border: 1px solid var(--border); border-radius: .5rem; color: var(--brand-text); }
   .warn { background: var(--warn-bg); border: 1px solid var(--warn-border); color: var(--warn-text); padding: .6rem .8rem; border-radius: .35rem; font-size: .8rem; margin-top: 1rem; }
   .advisory { background: var(--warn-bg); border: 1px solid var(--warn-border); color: var(--warn-text); padding: .65rem .8rem; border-radius: .35rem; font-size: .85rem; margin: .5rem 0; }
   .advisory + .advisory { margin-top: .4rem; }
@@ -390,6 +361,7 @@ function renderClaimPage(input: {
 <p>${input.message}</p>
 ${advisoryBlock}
 ${formBlock}
+${codeBlock}
 </body></html>`;
 }
 

--- a/agent-services/src/routes/home.ts
+++ b/agent-services/src/routes/home.ts
@@ -124,7 +124,7 @@ function renderHtml(): string {
 
 <section id="step-3" class="track-anon" hidden>
   <h2><span class="num">3</span>Register anonymously</h2>
-  <p>An agent without a user identity POSTs <code>{ "type": "anonymous" }</code> to <code>/agent/identity</code>. The service returns a service-signed <code>identity_assertion</code> bound to the new registration plus a <code>claim_token</code> for the human-handoff ceremony.</p>
+  <p>An agent without a user identity POSTs <code>{ "type": "anonymous" }</code> to <code>/agent/identity</code>. The service returns a service-signed assertion under <code>identity.assertion</code> plus a <code>claim.token</code> for the later human-handoff ceremony.</p>
   <div class="label">Request</div>
   <div class="req"><pre>POST /agent/identity
 Content-Type: application/json
@@ -136,7 +136,7 @@ Content-Type: application/json
 
 <section id="step-4" class="track-anon" hidden>
   <h2><span class="num">4</span>Exchange the assertion for a pre-claim access_token</h2>
-  <p>The agent POSTs the <code>identity_assertion</code> to <code>/oauth2/token</code> with the RFC 7523 JWT-bearer grant type. The response is a standard OAuth token envelope; the <code>scope</code> reflects the unclaimed pre-claim scope set.</p>
+  <p>The agent POSTs <code>identity.assertion</code> to <code>/oauth2/token</code> with the RFC 7523 JWT-bearer grant type. The response is a standard OAuth token envelope; the <code>scope</code> reflects the unclaimed pre-claim scope set.</p>
   <div class="label">Request</div>
   <div class="req" id="anon-exchange-req"><pre></pre></div>
   <button class="primary" type="button" data-action="anon-exchange">Exchange at /oauth2/token</button>
@@ -151,9 +151,9 @@ Content-Type: application/json
 </section>
 
 <section id="step-6" class="track-anon" hidden>
-  <h2><span class="num">6</span>Initiate the claim ceremony</h2>
-  <p>The agent invites a human to take ownership. <code>POST /agent/identity/claim</code> returns a <code>user_code</code> (to surface to the user) and a <code>verification_uri</code> (where they sign in and type the code). Shape follows <a href="https://datatracker.ietf.org/doc/html/rfc8628" target="_blank">RFC 8628 device authorization</a>.</p>
-  <label>Claiming user email
+  <h2><span class="num">6</span>Start the claim ceremony</h2>
+  <p>The agent invites a human to take ownership. <code>POST /agent/identity/claim</code> — <code>type</code> is always <code>service_auth</code> (the claim method), even for an anonymous registration — returns an <code>attempt.verification_uri</code> to hand the user. No code comes back to the agent; it's shown to the user on the page.</p>
+  <label>Claiming user email (login_hint)
     <input id="anon-claim-email" value="alice@example.com">
   </label>
   <div class="label">Request</div>
@@ -163,21 +163,26 @@ Content-Type: application/json
 </section>
 
 <section id="step-7" class="track-anon" hidden>
-  <h2><span class="num">7</span>Surface the code to the user</h2>
-  <p>The agent shows the user the verification URL and the 6-digit code. The user opens the URL, signs in to the service, and types the code on the service-owned claim page. The code travels agent → user → service — it never goes back to the agent.</p>
+  <h2><span class="num">7</span>Hand off the link, then complete with the code</h2>
+  <p>The agent gives the user the verification URL — no code. The user opens it, signs in, confirms, and the service-owned page <em>reveals</em> a 6-digit code. The user reads that code back to the agent, which submits it to <code>/agent/identity/claim/complete</code>. The code travels service → user → agent. Completion returns the post-claim <code>identity.assertion</code> and a rotating <code>refresh_token</code>, and revokes the pre-claim token.</p>
   <div id="anon-ceremony"></div>
+  <label>Code the user read back
+    <input class="otp" id="anon-user-code" maxlength="6" inputmode="numeric" placeholder="000000">
+  </label>
+  <button class="primary" type="button" data-action="anon-complete">Complete claim</button>
+  <div id="anon-complete-out"></div>
 </section>
 
 <section id="step-8" class="track-anon" hidden>
-  <h2><span class="num">8</span>Poll <code>/oauth2/token</code> with the claim grant</h2>
-  <p>Polling happens at the standard token endpoint with a profile-specific grant (<code>urn:workos:agent-auth:grant-type:claim</code>) — custom URN, so it doesn't collide with services that also implement standard RFC 8628 device auth. While the user is still in the ceremony: <code>{ "error": "authorization_pending" }</code>. On completion: a standard OAuth token response, with a fresh post-claim access_token plus a v2 <code>identity_assertion</code> (this one has the user's email populated, unlike the pre-claim v1).</p>
-  <button class="primary" type="button" data-action="anon-poll">Poll once</button>
-  <div id="anon-poll-out"></div>
+  <h2><span class="num">8</span>Exchange the post-claim assertion</h2>
+  <p>The post-claim <code>identity.assertion</code> goes back to <code>/oauth2/token</code> (same JWT-bearer grant). This one resolves to a claimed registration, so it mints an access_token with the full post-claim scope set.</p>
+  <button class="primary" type="button" data-action="anon-exchange-post">Exchange at /oauth2/token</button>
+  <div id="anon-exchange-post-out"></div>
 </section>
 
 <section id="step-9" class="track-anon" hidden>
   <h2><span class="num">9</span>Call with the post-claim access_token</h2>
-  <p>The access_token from the claim grant has the full post-claim scope set. The pre-claim access_token was revoked at ceremony completion.</p>
+  <p>The post-claim access_token carries the full scope set. The pre-claim access_token was revoked at ceremony completion.</p>
   <button class="primary" type="button" data-action="anon-call-post">Call /api/resource</button>
   <div id="anon-post-out"></div>
 </section>
@@ -185,11 +190,11 @@ Content-Type: application/json
 </div>
 
 <div class="track">
-<p class="track-header email" id="track-b-header" hidden>Track B — Email-verification registration</p>
+<p class="track-header email" id="track-b-header" hidden>Track B — service_auth registration</p>
 
 <section id="step-10" class="track-email" hidden>
-  <h2><span class="num">10</span>Register with an email assertion</h2>
-  <p>The agent has the user's email but no provider-signed assertion. It POSTs <code>/agent/identity</code> with <code>type: service_auth</code>. The response bundles the ceremony block (<code>user_code</code>, <code>verification_uri</code>, <code>interval</code>) — no separate <code>/claim</code> call needed.</p>
+  <h2><span class="num">10</span>Register with a service_auth login_hint</h2>
+  <p>The agent has the user's email but no provider-signed assertion. It POSTs <code>/agent/identity</code> with <code>type: service_auth</code>. The response bundles the first attempt under <code>claim.attempt.verification_uri</code> — no separate <code>/claim</code> call needed.</p>
   <label>User email
     <input id="email-assertion" value="alice@example.com">
   </label>
@@ -200,23 +205,31 @@ Content-Type: application/json
 </section>
 
 <section id="step-11" class="track-email" hidden>
-  <h2><span class="num">11</span>Surface the code to the user</h2>
-  <p>Same as Track A: the agent shows the user the verification URL and the 6-digit code. The user signs in to the service (as the asserted email) and types the code on the claim page.</p>
+  <h2><span class="num">11</span>Hand off the link, then complete with the code</h2>
+  <p>Same handoff as Track A: the agent gives the user the verification URL; the user signs in, confirms, and reads back the 6-digit code the page reveals. The agent submits it to <code>/agent/identity/claim/complete</code> and collects the <code>identity.assertion</code> + <code>refresh_token</code>.</p>
   <div id="email-ceremony"></div>
+  <label>Code the user read back
+    <input class="otp" id="email-user-code" maxlength="6" inputmode="numeric" placeholder="000000">
+  </label>
+  <button class="primary" type="button" data-action="email-complete">Complete claim</button>
+  <div id="email-complete-out"></div>
 </section>
 
 <section id="step-12" class="track-email" hidden>
-  <h2><span class="num">12</span>Poll <code>/oauth2/token</code> with the claim grant</h2>
-  <p>Same poll endpoint as Track A. While pending: <code>{ "error": "authorization_pending" }</code>. On completion: standard OAuth token response with a fresh access_token plus an <code>identity_assertion</code> (the agent uses this for jwt-bearer refreshes when the access_token expires).</p>
-  <button class="primary" type="button" data-action="email-poll">Poll once</button>
-  <div id="email-poll-out"></div>
+  <h2><span class="num">12</span>Exchange the assertion at <code>/oauth2/token</code></h2>
+  <p>The <code>identity.assertion</code> goes to the OAuth token endpoint with the RFC 7523 JWT-bearer grant; the response is a standard access_token with the post-claim scope set.</p>
+  <div class="label">Request</div>
+  <div class="req" id="email-token-req"><pre></pre></div>
+  <button class="primary" type="button" data-action="email-exchange">Exchange</button>
+  <div id="email-exchange-out"></div>
 </section>
 
 <section id="step-13" class="track-email" hidden>
   <h2><span class="num">13</span>Call <code>/api/resource</code></h2>
-  <p>The access_token from the claim grant goes straight to the API. No re-exchange needed — the claim grant already returned a usable credential.</p>
+  <p>With the post-claim access_token the agent calls the protected API.</p>
   <button class="primary" type="button" data-action="email-call">Call /api/resource</button>
   <div id="email-call-out"></div>
+  <p class="note" style="margin-top:1rem">When the assertion later expires, the agent doesn't re-register — it POSTs <code>{ "type": "refresh", "refresh_token": "…" }</code> to <code>/agent/identity</code> for a fresh assertion (and a rotated refresh token).</p>
 </section>
 
 </div>
@@ -225,8 +238,8 @@ Content-Type: application/json
 <p class="track-header ia" id="track-c-header" hidden>Track C — ID-JAG identity assertion</p>
 
 <section id="step-14" hidden>
-  <h2><span class="num">14</span>Exchange an ID-JAG for an identity_assertion</h2>
-  <p>Paste an ID-JAG minted by the provider (run the <a href="${providerHint}" target="_blank">provider demo</a> through its exchange step, then copy the <code>assertion</code> value). The consumer verifies the signature against the provider's JWKS, enforces replay protection, and returns a service-signed identity_assertion bound to the matched user.</p>
+  <h2><span class="num">14</span>Exchange an ID-JAG for an identity assertion</h2>
+  <p>Paste an ID-JAG minted by the provider (run the <a href="${providerHint}" target="_blank">provider demo</a> through its exchange step, then copy the <code>assertion</code> value). The consumer verifies the signature against the provider's JWKS, enforces replay protection, and returns a service-signed assertion under <code>identity.assertion</code> bound to the matched user.</p>
   <label>ID-JAG assertion
     <textarea id="assertion" placeholder="eyJhbGc..."></textarea>
   </label>
@@ -238,7 +251,7 @@ Content-Type: application/json
 
 <section id="step-15" hidden>
   <h2><span class="num">15</span>Exchange the assertion at /oauth2/token</h2>
-  <p>The service-signed identity_assertion goes to the OAuth token endpoint with the RFC 7523 JWT-bearer grant; the response is a standard access_token.</p>
+  <p>The service-signed <code>identity.assertion</code> goes to the OAuth token endpoint with the RFC 7523 JWT-bearer grant; the response is a standard access_token.</p>
   <div class="label">Request</div>
   <div class="req" id="token-req"><pre></pre></div>
   <button class="primary" type="button" data-action="token-exchange">Exchange</button>
@@ -252,7 +265,7 @@ Content-Type: application/json
   <div class="req" id="call-req"><pre></pre></div>
   <button class="primary" type="button" data-action="call">Call /api/resource</button>
   <div id="call-out"></div>
-  <p class="note" style="margin-top:1rem">Revocation has two surfaces. RFC 7009 token revocation at <code>/oauth2/revoke</code> kills one access_token; the agent can re-exchange the identity_assertion to mint a fresh one. The provider can also POST a <code>secevent+jwt</code> (RFC 8417 SET, delivered per RFC 8935) to <code>/agent/event/notify</code>, which invalidates all credentials for the <code>(iss, sub, aud)</code> — see the provider demo's revoke step.</p>
+  <p class="note" style="margin-top:1rem">Revocation has two surfaces. RFC 7009 token revocation at <code>/oauth2/revoke</code> kills one access_token; the agent can re-exchange the identity assertion to mint a fresh one. The provider can also POST a <code>secevent+jwt</code> (RFC 8417 SET, delivered per RFC 8935) to <code>/agent/event/notify</code>, which invalidates all credentials for the <code>(iss, sub, aud)</code> — see the provider demo's revoke step.</p>
 </section>
 </div>
 </div>
@@ -335,14 +348,15 @@ function updateCallPreview() {
 }
 function updateAnonExchangePreview() {
   const params = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
-    abbrev(state.anon_identity_assertion);
+    abbrev(state.anon_assertion);
   document.querySelector("#anon-exchange-req pre").textContent =
     "POST /oauth2/token\\nContent-Type: application/x-www-form-urlencoded\\n\\n" + params;
 }
 function updateAnonClaimPreview() {
   const body = {
+    type: "service_auth",
     claim_token: abbrev(state.anon_claim_token),
-    email: document.getElementById("anon-claim-email").value,
+    login_hint: document.getElementById("anon-claim-email").value,
   };
   document.querySelector("#anon-claim-req pre").textContent =
     "POST /agent/identity/claim\\nContent-Type: application/json\\n\\n" + jsonStr(body);
@@ -355,17 +369,25 @@ function updateEmailRegisterPreview() {
   document.querySelector("#email-register-req pre").textContent =
     "POST /agent/identity\\nContent-Type: application/json\\n\\n" + jsonStr(body);
 }
+function updateEmailTokenPreview() {
+  const params = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
+    abbrev(state.email_assertion);
+  document.querySelector("#email-token-req pre").textContent =
+    "POST /oauth2/token\\nContent-Type: application/x-www-form-urlencoded\\n\\n" + params;
+}
 
-function renderCeremony(containerId, ceremony) {
+/*
+ * Renders the verification link the agent hands to the user. No code here —
+ * the user_code is shown to the user on the service-owned claim page and read
+ * back to the agent.
+ */
+function renderCeremony(containerId, verificationUri) {
   document.getElementById(containerId).innerHTML =
     '<div class="note">' +
-    '<p style="margin: 0 0 .5rem; color: var(--brand-text);"><strong>Show the user:</strong></p>' +
-    '<p style="margin: 0 0 .25rem;"><a href="' + escapeHtml(ceremony.verification_uri) + '" target="_blank">' +
-      escapeHtml(ceremony.verification_uri) + '</a></p>' +
-    '<p style="margin: 0; font-family: ui-monospace, monospace; font-size: 1.4rem; letter-spacing: .3rem; color: var(--brand-text);">Code: ' +
-      escapeHtml(ceremony.user_code) + '</p>' +
-    '<p style="margin: .5rem 0 0; font-size: .8rem;">Expires in ' + ceremony.expires_in +
-      's. Poll interval: ' + ceremony.interval + 's.</p>' +
+    '<p style="margin: 0 0 .5rem; color: var(--brand-text);"><strong>Give the user this link (open it to run the ceremony):</strong></p>' +
+    '<p style="margin: 0;"><a href="' + escapeHtml(verificationUri) + '" target="_blank">' +
+      escapeHtml(verificationUri) + '</a></p>' +
+    '<p style="margin: .5rem 0 0; font-size: .8rem;">They sign in, confirm, and read back the 6-digit code the page shows. Paste it below.</p>' +
     '</div>';
 }
 
@@ -390,10 +412,12 @@ document.body.addEventListener("click", (e) => {
   if (a === "anon-exchange") anonExchange();
   if (a === "anon-call-pre") anonCallPre();
   if (a === "anon-claim") anonClaim();
-  if (a === "anon-poll") anonPoll();
+  if (a === "anon-complete") anonComplete();
+  if (a === "anon-exchange-post") anonExchangePost();
   if (a === "anon-call-post") anonCallPost();
   if (a === "email-register") emailRegister();
-  if (a === "email-poll") emailPoll();
+  if (a === "email-complete") emailComplete();
+  if (a === "email-exchange") emailExchange();
   if (a === "email-call") emailCall();
   if (a === "exchange") exchange();
   if (a === "token-exchange") tokenExchange();
@@ -441,9 +465,9 @@ async function anonRegister() {
   });
   document.getElementById("anon-register-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.anon_identity_assertion = r.body.identity_assertion;
-  state.anon_claim_token = r.body.claim_token;
-  state.anon_registration_id = r.body.registration_id;
+  state.anon_assertion = r.body.identity.assertion;
+  state.anon_claim_token = r.body.claim.token;
+  state.anon_registration_id = r.body.id;
   updateAnonExchangePreview();
   updateAnonClaimPreview();
   markDone("step-3");
@@ -453,7 +477,7 @@ async function anonRegister() {
 async function anonExchange() {
   const r = await formFetch("/oauth2/token", {
     grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    assertion: state.anon_identity_assertion,
+    assertion: state.anon_assertion,
   });
   document.getElementById("anon-exchange-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
@@ -472,29 +496,42 @@ async function anonCallPre() {
 
 async function anonClaim() {
   const body = {
+    type: "service_auth",
     claim_token: state.anon_claim_token,
-    email: document.getElementById("anon-claim-email").value,
+    login_hint: document.getElementById("anon-claim-email").value,
   };
   const r = await jsonFetch("/agent/identity/claim", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("anon-claim-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  renderCeremony("anon-ceremony", r.body.claim_attempt);
+  renderCeremony("anon-ceremony", r.body.attempt.verification_uri);
   markDone("step-6");
   reveal("step-7");
-  document.getElementById("step-8").hidden = false;
 }
 
-async function anonPoll() {
-  const r = await formFetch("/oauth2/token", {
-    grant_type: "urn:workos:agent-auth:grant-type:claim",
+async function anonComplete() {
+  const body = {
     claim_token: state.anon_claim_token,
-  });
-  document.getElementById("anon-poll-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+    user_code: document.getElementById("anon-user-code").value.trim(),
+  };
+  const r = await jsonFetch("/agent/identity/claim/complete", { method: "POST", body: JSON.stringify(body) });
+  document.getElementById("anon-complete-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  /* Claim grant succeeded: response carries access_token + v2 identity_assertion. */
-  state.anon_access_token = r.body.access_token;
-  state.anon_identity_assertion = r.body.identity_assertion;
+  /* Post-claim identity: v2 assertion (now carries the user's email) + refresh token. */
+  state.anon_assertion = r.body.identity.assertion;
+  state.anon_refresh_token = r.body.identity.refresh_token.value;
+  updateAnonExchangePreview();
   markDone("step-7");
+  reveal("step-8");
+}
+
+async function anonExchangePost() {
+  const r = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.anon_assertion,
+  });
+  document.getElementById("anon-exchange-post-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+  if (!r.ok) return;
+  state.anon_access_token = r.body.access_token;
   markDone("step-8");
   reveal("step-9");
 }
@@ -516,35 +553,41 @@ async function emailRegister() {
   const r = await jsonFetch("/agent/identity", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("email-register-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.email_claim_token = r.body.claim_token;
-  state.email_registration_id = r.body.registration_id;
-  renderCeremony("email-ceremony", r.body.claim);
+  state.email_claim_token = r.body.claim.token;
+  state.email_registration_id = r.body.id;
+  renderCeremony("email-ceremony", r.body.claim.attempt.verification_uri);
   markDone("step-10");
   reveal("step-11");
-  document.getElementById("step-12").hidden = false;
 }
 
-async function emailPoll() {
-  const r = await formFetch("/oauth2/token", {
-    grant_type: "urn:workos:agent-auth:grant-type:claim",
+async function emailComplete() {
+  const body = {
     claim_token: state.email_claim_token,
+    user_code: document.getElementById("email-user-code").value.trim(),
+  };
+  const r = await jsonFetch("/agent/identity/claim/complete", { method: "POST", body: JSON.stringify(body) });
+  document.getElementById("email-complete-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+  if (!r.ok) return;
+  state.email_assertion = r.body.identity.assertion;
+  state.email_refresh_token = r.body.identity.refresh_token.value;
+  updateEmailTokenPreview();
+  markDone("step-11");
+  reveal("step-12");
+}
+
+async function emailExchange() {
+  const r = await formFetch("/oauth2/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: state.email_assertion,
   });
-  document.getElementById("email-poll-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
+  document.getElementById("email-exchange-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
   state.email_access_token = r.body.access_token;
-  state.email_identity_assertion = r.body.identity_assertion;
-  markDone("step-11");
   markDone("step-12");
   reveal("step-13");
 }
 
 async function emailCall() {
-  /*
-   * The claim grant already returned an access_token alongside the v2
-   * identity_assertion — just use it. (The identity_assertion is what the
-   * agent uses to mint future access_tokens via jwt-bearer once this one
-   * expires.)
-   */
   const r = await jsonFetch("/api/resource", {
     headers: { authorization: "Bearer " + state.email_access_token },
   });
@@ -567,7 +610,7 @@ async function exchange() {
   const r = await jsonFetch("/agent/identity", { method: "POST", body: JSON.stringify(body) });
   document.getElementById("exchange-out").innerHTML = resBlock(r.status, null, r.body, r.ok);
   if (!r.ok) return;
-  state.identity_assertion = r.body.identity_assertion;
+  state.identity_assertion = r.body.identity.assertion;
   updateTokenPreview();
   markDone("step-14");
   reveal("step-15");

--- a/agent-services/src/routes/token.ts
+++ b/agent-services/src/routes/token.ts
@@ -1,37 +1,28 @@
 import express, { Router } from "express";
 import { config } from "../config.js";
 import {
-  claimGrantBody,
   jwtBearerGrantBody,
   parseBody,
   revocationEndpointBody,
 } from "../schemas.js";
 import {
   type Registration,
-  findRegistrationByClaimHash,
   findRegistrationById,
   issueAccessToken,
   revokeCredential,
-  sha256Hex,
-  users,
 } from "../store.js";
-import { signServiceIdJag, verifyServiceIdJag } from "../verify.js";
+import { verifyServiceIdJag } from "../verify.js";
 
 /*
  * OAuth credential surface for the agent-auth profile.
  *
- * /oauth2/token handles two grants, dispatched on grant_type:
+ * /oauth2/token handles one grant:
  *   - urn:ietf:params:oauth:grant-type:jwt-bearer (RFC 7523) — exchanges a
- *     service-signed identity_assertion for an access_token. The assertion's
+ *     service-signed identity assertion for an access_token. The assertion's
  *     `sub` resolves to a registration; the scope set is derived from the
- *     registration's state.
- *   - urn:workos:agent-auth:grant-type:claim — profile-specific grant for
- *     claim-ceremony polling. Borrows RFC 8628 §3.5 semantics (returns
- *     authorization_pending while waiting, expired_token on closed window,
- *     standard OAuth token response on completion + identity_assertion
- *     extension). Uses a custom URN rather than the IANA device_code grant
- *     so it doesn't collide with services that also implement standard
- *     device authorization at the same endpoint.
+ *     registration's state. The claim ceremony does not run through here —
+ *     the agent completes it at /agent/identity/claim/complete and gets a
+ *     refresh token for the assertion refresh path.
  *
  * /oauth2/revoke (RFC 7009) — kills a single access_token by value. 200 on
  * success, idempotent, no enumeration leakage on unknown tokens.
@@ -42,13 +33,6 @@ export const tokenRouter = Router();
 const formParser = express.urlencoded({ extended: false });
 
 const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-/**
- * Profile-specific grant URN for claim-ceremony polling. Custom (not IANA-
- * registered) so it doesn't collide with services that also implement
- * standard RFC 8628 device authorization at the same token endpoint —
- * routing happens at grant_type, not by inspecting the bearer value.
- */
-const CLAIM_GRANT = "urn:workos:agent-auth:grant-type:claim";
 
 type OAuthErrorCode =
   | "invalid_request"
@@ -57,11 +41,7 @@ type OAuthErrorCode =
   | "unauthorized_client"
   | "unsupported_grant_type"
   | "invalid_scope"
-  /** Borrowed from RFC 8628 §3.5 for the device-auth-shaped claim grant. */
-  | "authorization_pending"
-  | "slow_down"
-  | "access_denied"
-  | "expired_token";
+  | "access_denied";
 
 /**
  * Per RFC 6749 §5.1, the AS MUST set Cache-Control: no-store and Pragma:
@@ -89,9 +69,6 @@ tokenRouter.post(config.tokenEndpointPath, formParser, async (req, res) => {
 
   if (grantType === JWT_BEARER_GRANT) {
     return handleJwtBearerGrant(req, res);
-  }
-  if (grantType === CLAIM_GRANT) {
-    return handleClaimGrant(req, res);
   }
   return oauthError(
     res,
@@ -140,92 +117,6 @@ async function handleJwtBearerGrant(
   );
   setOAuthHeaders(res);
   res.json(tokenResponse(credential));
-}
-
-async function handleClaimGrant(
-  req: express.Request,
-  res: express.Response,
-): Promise<void> {
-  const parsed = parseBody(claimGrantBody, req.body);
-  if (!parsed.ok) {
-    oauthError(res, "invalid_request", parsed.message);
-    return;
-  }
-
-  const registration = findRegistrationByClaimHash(
-    sha256Hex(parsed.value.claim_token),
-  );
-  if (!registration) {
-    oauthError(res, "expired_token", "Unknown or expired claim_token.");
-    return;
-  }
-  if (registration.status === "expired") {
-    oauthError(res, "expired_token", "The claim ceremony window has closed.");
-    return;
-  }
-  if (registration.status !== "claimed") {
-    /*
-     * The user_code itself expires faster than the outer claim window
-     * (userCodeTtlSeconds vs claim.expires_at). If the user_code window
-     * has closed but the registration is still active, the form-action
-     * endpoint would refuse a submission and the agent would otherwise
-     * poll authorization_pending until the outer window expires. Return
-     * expired_token so the agent knows to re-mint via /agent/identity/claim.
-     */
-    const attempt = registration.claim?.attempt;
-    if (attempt && attempt.user_code_expires_at.getTime() < Date.now()) {
-      oauthError(
-        res,
-        "expired_token",
-        "The user_code window has closed. Re-initiate the claim ceremony at the claim_endpoint.",
-      );
-      return;
-    }
-    /*
-     * RFC 8628 §3.5: while the user hasn't completed the ceremony, return
-     * authorization_pending. The agent is expected to retry after
-     * `interval` seconds.
-     *
-     * A production service should also issue `slow_down` here when it
-     * detects polling faster than `interval` — typically by recording the
-     * last-poll timestamp per claim_token (Redis SETEX or similar) and
-     * returning `slow_down` when the gap is below the advertised cadence.
-     * Omitted from this demo to keep the store in-memory; the error code
-     * is declared in OAuthErrorCode so callers can branch on it if added.
-     */
-    oauthError(
-      res,
-      "authorization_pending",
-      "The user has not yet completed the ceremony.",
-    );
-    return;
-  }
-
-  const credential = issueAccessTokenForRegistration(registration);
-  /*
-   * Mint a fresh "v2" identity_assertion that reflects the post-claim
-   * state — for anonymous, this is the first time we know the user's
-   * email; the v1 assertion the agent already holds has no identity
-   * claims. The agent uses v2 for future jwt-bearer refreshes.
-   */
-  const user = registration.user_id
-    ? users.get(registration.user_id)
-    : undefined;
-  const { jwt, expiresAt } = await signServiceIdJag({
-    registration,
-    email: user?.email,
-    emailVerified: user?.email_verified,
-  });
-
-  console.log(
-    `[token] claim grant succeeded for registration=${registration.id}; issued access_token + v2 assertion`,
-  );
-  setOAuthHeaders(res);
-  res.json({
-    ...tokenResponse(credential),
-    identity_assertion: jwt,
-    assertion_expires: expiresAt.toISOString(),
-  });
 }
 
 function issueAccessTokenForRegistration(registration: Registration) {

--- a/agent-services/src/routes/well-known.ts
+++ b/agent-services/src/routes/well-known.ts
@@ -27,10 +27,7 @@ wellKnownRouter.get("/.well-known/oauth-authorization-server", (_req, res) => {
     issuer: config.baseUrl,
     token_endpoint: `${config.baseUrl}${config.tokenEndpointPath}`,
     revocation_endpoint: `${config.baseUrl}${config.revocationEndpointPath}`,
-    grant_types_supported: [
-      "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      "urn:workos:agent-auth:grant-type:claim",
-    ],
+    grant_types_supported: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
 
     agent_auth: {
       skill: `${config.baseUrl}/auth.md`,

--- a/agent-services/src/schemas.ts
+++ b/agent-services/src/schemas.ts
@@ -17,15 +17,42 @@ const anonymousBody = z.object({
   type: z.literal("anonymous"),
 });
 
+/**
+ * Exchanges a rotating refresh token (issued to service_auth and claimed
+ * registrations at claim/complete) for a fresh identity assertion. Anonymous
+ * pre-claim and id_jag registrations have no refresh token — they re-exchange
+ * the assertion or re-register instead.
+ */
+const refreshBody = z.object({
+  type: z.literal("refresh"),
+  refresh_token: z.string().min(1),
+});
+
 export const agentAuthBody = z.union([
   idJagAssertionBody,
   serviceAuthBody,
   anonymousBody,
+  refreshBody,
 ]);
 
+/**
+ * Starts (or re-mints) a claim attempt. `type` is the claim method, not the
+ * registration kind — anonymous registrations are claimed via `service_auth`
+ * too. The `login_hint` binds the attempt to the human who may complete it.
+ */
 export const claimBody = z.object({
+  type: z.literal("service_auth"),
   claim_token: z.string().min(1),
-  email: z.email(),
+  login_hint: z.email(),
+});
+
+/**
+ * Agent-facing claim completion. The agent presents its claim token plus the
+ * user_code the confirming human read off the claim page and relayed back.
+ */
+export const claimCompleteBody = z.object({
+  claim_token: z.string().min(1),
+  user_code: z.string().regex(/^\d{6}$/, "user_code must be a 6-digit code"),
 });
 
 /** Mock IdP sign-in form. */
@@ -34,10 +61,13 @@ export const loginFormBody = z.object({
   return_to: z.string().optional(),
 });
 
-/** User-facing claim form. */
-export const claimFormBody = z.object({
+/**
+ * User-facing claim confirmation form. The signed-in human confirms; the page
+ * then reveals the user_code for them to read back to the agent. No code is
+ * typed here — it travels service → user → agent, not the other way.
+ */
+export const claimConfirmFormBody = z.object({
   claim_attempt_token: z.string().min(1),
-  user_code: z.string().regex(/^\d{6}$/, "user_code must be a 6-digit code"),
 });
 
 /**
@@ -50,17 +80,6 @@ export const jwtBearerGrantBody = z.object({
   grant_type: z.literal("urn:ietf:params:oauth:grant-type:jwt-bearer"),
   assertion: z.string().min(1),
   resource: z.string().url().optional(),
-});
-
-/**
- * Profile-specific grant for claim-ceremony polling. Device-authorization-
- * shaped (RFC 8628 §3.4 semantics) but uses our own grant URN so it doesn't
- * collide with services that also implement standard device auth. The
- * `claim_token` from the registration response is the polling bearer.
- */
-export const claimGrantBody = z.object({
-  grant_type: z.literal("urn:workos:agent-auth:grant-type:claim"),
-  claim_token: z.string().min(1),
 });
 
 /** RFC 7009 token revocation. */

--- a/agent-services/src/store.ts
+++ b/agent-services/src/store.ts
@@ -35,12 +35,6 @@ export type Delegation = {
 export type RegistrationKind = "anonymous" | "service_auth" | "id_jag";
 
 /**
- * The user-facing leg of the claim ceremony. Tracks the `claim_attempt_token`
- * that binds the verification URL to this registration and the `user_code`
- * the agent surfaces to the user. Naming follows RFC 8628 device
- * authorization.
- */
-/**
  * The identifier the agent hinted at — used to surface a mismatch advisory
  * if the signed-in user doesn't match. The wire stays a CIBA-shaped opaque
  * string; routes call `classifyLoginHint` at the edge to tag it. Structured
@@ -56,20 +50,35 @@ export function classifyLoginHint(s: string): LoginHint | undefined {
   return undefined;
 }
 
+/**
+ * The user-facing leg of the claim ceremony. Tracks the `claim_attempt_token`
+ * that binds the verification URL to this registration and the `user_code`
+ * the service reveals to the signed-in human — who reads it back to the agent.
+ * Naming follows RFC 8628 device authorization, but the code travels service
+ * → user → agent, so it's held plaintext here to reveal on the claim page
+ * (never returned to the agent) and matched when the agent submits it at
+ * claim/complete.
+ */
 export type RegistrationClaimAttempt = {
   id: string;
   /** Hash of the claim_attempt_token embedded in the verification URL. */
   view_token_hash: string;
   view_expires_at: Date;
-  /** Hash of the 6-digit user_code the agent surfaces to the user. */
-  user_code_hash: string;
-  user_code_generated_at: Date;
+  /** The 6-digit code, revealed to the confirming human to read back. */
+  user_code: string;
   user_code_expires_at: Date;
   /**
    * The hint the agent supplied when minting this attempt. Per-attempt so a
    * re-mint can carry a corrected hint without affecting prior attempts.
    */
   login_hint?: LoginHint;
+  /**
+   * Set when the signed-in human confirms on the claim page. Until then the
+   * agent's claim/complete returns `not_confirmed`. Captures which user
+   * confirmed so completion binds the registration to them.
+   */
+  confirmed_at?: Date;
+  confirmed_user_id?: string;
 };
 
 /**
@@ -146,6 +155,61 @@ export const credentials = new Map<string, Credential>();
 export const delegations = new Map<string, Delegation>();
 export const registrations = new Map<string, Registration>();
 export const seenJtis = new Map<string, number>();
+
+/**
+ * Rotating refresh tokens, keyed by hash. Issued to service_auth and claimed
+ * registrations at claim/complete; exchanged at /agent/identity (type:
+ * refresh) for a fresh identity assertion. Each exchange spends the presented
+ * token and mints a new one — a presented-but-spent token is a reuse signal.
+ */
+export type RefreshToken = {
+  token_hash: string;
+  registration_id: string;
+  expires_at: Date;
+  spent: boolean;
+};
+export const refreshTokens = new Map<string, RefreshToken>();
+
+export function mintRefreshToken(registrationId: string): {
+  value: string;
+  expiresAt: Date;
+} {
+  const value = `art_${randomBytes(24).toString("base64url")}`;
+  const expiresAt = new Date(Date.now() + config.refreshTokenTtlSeconds * 1000);
+  const token_hash = sha256Hex(value);
+  refreshTokens.set(token_hash, {
+    token_hash,
+    registration_id: registrationId,
+    expires_at: expiresAt,
+    spent: false,
+  });
+  return { value, expiresAt };
+}
+
+export type RotateRefreshTokenResult =
+  | { ok: true; registration: Registration; value: string; expiresAt: Date }
+  | { ok: false; error: "invalid" | "expired" | "spent" };
+
+export function rotateRefreshToken(
+  plaintext: string,
+): RotateRefreshTokenResult {
+  const record = refreshTokens.get(sha256Hex(plaintext));
+  if (!record) return { ok: false, error: "invalid" };
+  if (record.spent) return { ok: false, error: "spent" };
+  if (record.expires_at.getTime() < Date.now()) {
+    return { ok: false, error: "expired" };
+  }
+  const registration = registrations.get(record.registration_id);
+  if (!registration) return { ok: false, error: "invalid" };
+  record.spent = true;
+  const next = mintRefreshToken(record.registration_id);
+  return {
+    ok: true,
+    registration,
+    value: next.value,
+    expiresAt: next.expiresAt,
+  };
+}
 
 const seeded: User[] = [
   {
@@ -327,17 +391,18 @@ export function createAnonymousRegistration(): {
 }
 
 /**
- * service_auth registrations bundle the claim ceremony: the agent
- * receives a `user_code` and `verification_uri` in the registration response
- * and surfaces both to the user. The user signs in to the service, types the
- * code on the claim page, and ownership transfers.
+ * service_auth registrations bundle the first claim attempt: the agent
+ * receives a `verification_uri` (no code) in the registration response and
+ * hands it to the user. The user signs in to the service and confirms; the
+ * claim page then reveals the `user_code` for the user to read back to the
+ * agent, which submits it at claim/complete.
  */
-export function createServiceAuthRegistration(input: { login_hint: LoginHint }): {
+export function createServiceAuthRegistration(input: {
+  login_hint: LoginHint;
+}): {
   registration: Registration;
   claimTokenPlaintext: string;
   claimViewTokenPlaintext: string;
-  userCode: string;
-  userCodeExpiresAt: Date;
 } {
   const now = new Date();
   const registrationId = `reg_${randomBytes(16).toString("base64url")}`;
@@ -358,21 +423,14 @@ export function createServiceAuthRegistration(input: { login_hint: LoginHint }):
         view_expires_at: new Date(
           now.getTime() + config.claimViewTokenTtlSeconds * 1000,
         ),
-        user_code_hash: code.hash,
-        user_code_generated_at: now,
+        user_code: code.plaintext,
         user_code_expires_at: code.expiresAt,
         login_hint: input.login_hint,
       },
     },
   });
   registrations.set(registration.id, registration);
-  return {
-    registration,
-    claimTokenPlaintext,
-    claimViewTokenPlaintext,
-    userCode: code.plaintext,
-    userCodeExpiresAt: code.expiresAt,
-  };
+  return { registration, claimTokenPlaintext, claimViewTokenPlaintext };
 }
 
 function idJagRegistrationKey(iss: string, sub: string, aud: string): string {
@@ -406,8 +464,6 @@ export type FindOrCreateIdJagResult =
       registration: Registration;
       claimTokenPlaintext: string;
       claimViewTokenPlaintext: string;
-      userCode: string;
-      userCodeExpiresAt: Date;
     };
 
 export function findOrCreateIdJagRegistration(input: {
@@ -461,8 +517,7 @@ export function findOrCreateIdJagRegistration(input: {
       view_expires_at: new Date(
         now.getTime() + config.claimViewTokenTtlSeconds * 1000,
       ),
-      user_code_hash: code.hash,
-      user_code_generated_at: now,
+      user_code: code.plaintext,
       user_code_expires_at: code.expiresAt,
       login_hint: { kind: "email" as const, value: input.context.email },
     },
@@ -471,7 +526,7 @@ export function findOrCreateIdJagRegistration(input: {
   if (existing) {
     /*
      * Pending step-up exists — re-issue ceremony. Prior URL/code stop
-     * working; the agent surfaces the new ones to the user.
+     * working; the agent surfaces the new verification_uri to the user.
      */
     existing.claim = claim;
     return {
@@ -479,8 +534,6 @@ export function findOrCreateIdJagRegistration(input: {
       registration: existing,
       claimTokenPlaintext,
       claimViewTokenPlaintext,
-      userCode: code.plaintext,
-      userCodeExpiresAt: code.expiresAt,
     };
   }
 
@@ -497,8 +550,6 @@ export function findOrCreateIdJagRegistration(input: {
     registration,
     claimTokenPlaintext,
     claimViewTokenPlaintext,
-    userCode: code.plaintext,
-    userCodeExpiresAt: code.expiresAt,
   };
 }
 
@@ -529,8 +580,6 @@ export function recordClaimAttempt(
   login_hint: LoginHint,
 ): {
   claimViewTokenPlaintext: string;
-  userCode: string;
-  userCodeExpiresAt: Date;
 } {
   if (!registration.claim) {
     throw new Error("registration has no claim handle");
@@ -544,34 +593,56 @@ export function recordClaimAttempt(
     view_expires_at: new Date(
       now.getTime() + config.claimViewTokenTtlSeconds * 1000,
     ),
-    user_code_hash: code.hash,
-    user_code_generated_at: now,
+    user_code: code.plaintext,
     user_code_expires_at: code.expiresAt,
     login_hint,
   };
-  return {
-    claimViewTokenPlaintext: plaintext,
-    userCode: code.plaintext,
-    userCodeExpiresAt: code.expiresAt,
-  };
+  return { claimViewTokenPlaintext: plaintext };
 }
 
 /**
- * Mints a 6-digit user_code with its hash + expiry. Caller embeds the hash
- * on the attempt; the plaintext is returned to the agent (and read by the
- * user from the agent's UI).
+ * Mints a 6-digit user_code with its expiry. The plaintext is held on the
+ * attempt and revealed to the confirming human on the claim page (never
+ * returned to the agent); the agent submits it back at claim/complete.
  */
 function mintUserCode(now: Date): {
   plaintext: string;
-  hash: string;
   expiresAt: Date;
 } {
   const plaintext = String(randomInt(0, 1_000_000)).padStart(6, "0");
   return {
     plaintext,
-    hash: sha256Hex(plaintext),
     expiresAt: new Date(now.getTime() + config.userCodeTtlSeconds * 1000),
   };
+}
+
+export type ConfirmClaimViewResult =
+  | { ok: true; registration: Registration; userCode: string }
+  | { ok: false; error: "claim_expired" | "previously_claimed" };
+
+/**
+ * Called by the user-facing claim page after the signed-in human confirms.
+ * Binds the confirming user to the attempt and returns the user_code to
+ * reveal on the page. The agent never reaches this path — it later submits
+ * the code the user read back, at claim/complete.
+ */
+export function confirmClaimView(
+  registration: Registration,
+  signedInUser: User,
+): ConfirmClaimViewResult {
+  if (registration.status === "claimed") {
+    return { ok: false, error: "previously_claimed" };
+  }
+  if (registration.status === "expired") {
+    return { ok: false, error: "claim_expired" };
+  }
+  const attempt = registration.claim?.attempt;
+  if (!attempt) {
+    return { ok: false, error: "claim_expired" };
+  }
+  attempt.confirmed_at = new Date();
+  attempt.confirmed_user_id = signedInUser.id;
+  return { ok: true, registration, userCode: attempt.user_code };
 }
 
 export type CompleteClaimResult =
@@ -579,6 +650,7 @@ export type CompleteClaimResult =
   | {
       ok: false;
       error:
+        | "not_confirmed"
         | "user_code_invalid"
         | "user_code_expired"
         | "previously_claimed"
@@ -586,14 +658,14 @@ export type CompleteClaimResult =
     };
 
 /**
- * Called by the user-facing `/claim` form handler after authenticating the
- * user via the session cookie. The agent never reaches this code path —
- * it polls `/oauth2/token` with the claim grant for the resulting status.
+ * Agent-facing claim completion. The agent presents the user_code the human
+ * read off the claim page. We require the attempt to have been confirmed by
+ * a signed-in human first (`not_confirmed` otherwise), then bind the
+ * registration to that user.
  */
-export function completeClaim(
+export function completeClaimByAgent(
   registration: Registration,
   userCode: string,
-  signedInUser: User,
 ): CompleteClaimResult {
   if (registration.status === "claimed") {
     return { ok: false, error: "previously_claimed" };
@@ -605,26 +677,28 @@ export function completeClaim(
   if (!attempt) {
     return { ok: false, error: "claim_expired" };
   }
+  if (!attempt.confirmed_at || !attempt.confirmed_user_id) {
+    return { ok: false, error: "not_confirmed" };
+  }
   if (attempt.user_code_expires_at.getTime() < Date.now()) {
     return { ok: false, error: "user_code_expired" };
   }
-  if (sha256Hex(userCode) !== attempt.user_code_hash) {
+  if (userCode !== attempt.user_code) {
     return { ok: false, error: "user_code_invalid" };
   }
+  const user = users.get(attempt.confirmed_user_id);
+  if (!user) {
+    return { ok: false, error: "claim_expired" };
+  }
 
-  registration.user_id = signedInUser.id;
+  registration.user_id = user.id;
   registration.claimed_at = new Date();
-  /*
-   * Keep the claim handle around so the agent's poll can resolve the
-   * registration by claim_token after completion. `status === "claimed"`
-   * already prevents re-completion.
-   */
 
   if (registration.kind === "anonymous") {
     /*
-     * Revoke any pre-claim access_tokens. The agent's claim-grant poll on
-     * /oauth2/token will return a fresh post-claim access_token + v2
-     * identity_assertion; the pre-claim credentials are no longer the
+     * Revoke any pre-claim access_tokens. The agent re-exchanges the
+     * post-claim identity assertion returned by claim/complete for a fresh
+     * post-claim access_token; the pre-claim credentials are no longer the
      * canonical handle.
      */
     for (const cred of credentials.values()) {
@@ -639,12 +713,8 @@ export function completeClaim(
      * Step-up complete: bind the (iss, sub) → user delegation so future
      * ID-JAGs from this provider for this sub take the clean-match path.
      */
-    upsertDelegation(
-      registration.id_jag.iss,
-      registration.id_jag.sub,
-      signedInUser.id,
-    );
+    upsertDelegation(registration.id_jag.iss, registration.id_jag.sub, user.id);
   }
 
-  return { ok: true, registration, user: signedInUser };
+  return { ok: true, registration, user };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-md",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "pnpm --filter shared build && concurrently --names agent-provider,agent-service --prefix-colors blue,magenta \"pnpm --filter agent-providers dev\" \"pnpm --filter agent-services dev\"",


### PR DESCRIPTION
## Summary

Aligns AUTH.md (v0.7.0) and the sample service with the production WorkOS implementation, reversing the earlier decision to have agents poll for claim confirmation.

- **Claim flow direction reversed — polling removed.** The `urn:workos:agent-auth:grant-type:claim` polling grant is gone. Instead the human confirms at `verification_uri` and reads the `user_code` back to the agent, which finishes directly:
  ```http
  POST /agent/identity/claim/complete
  { "claim_token": "clm_...", "user_code": "123456" }
  ```
- **Nested response envelopes** matching production: `identity.{assertion,expires_at,refresh_token}` and `claim.{token,expires_at,url,attempt}`.
- **Refresh-token rotation** via a `refresh` registration path; error codes renamed to the WorkOS names (`claim_not_confirmed`, `invalid_grant`, ...).
- **RFC 8707 `resource`** honored on the jwt-bearer exchange.

The sample service (`agent-services/`) is updated to implement the reconciled flow end-to-end (registration, claim ceremony, completion, exchange, refresh), and the READMEs/CHANGELOG follow.

Branch authored by @m0tzy; PR opened on request. Note: #27 (the agent-side client) is based on this branch and targets it.

Link to Devin session: https://app.devin.ai/sessions/3bbcaf8fae804f3caff9e7394cfaf640
Open in Devin Desktop: https://app.devin.ai/desktop/session/3bbcaf8fae804f3caff9e7394cfaf640?variant=devin